### PR TITLE
feat: constrain event names to a type composed of specific string literals

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4,10 +4,12 @@ export interface BlueprintResource {
 }
 
 export interface BlueprintFunctionResourceEvent {
-  on: string[]
+  on: [BlueprintFunctionResourceEventName, ...BlueprintFunctionResourceEventName[]]
   filter?: string
   projection?: string
 }
+
+type BlueprintFunctionResourceEventName = 'publish'
 
 export interface BlueprintFunctionResource extends BlueprintResource {
   type: 'sanity.function.document'


### PR DESCRIPTION
also enforces at least one valid string in `event.on`

in the future if we want, we can add type tests for these kinds of changes to ensure we don't regress. i've used [`tsd`](https://www.npmjs.com/package/tsd) in the past with success here. e.g. [the slack node sdk type tests](https://github.com/slackapi/node-slack-sdk/blob/main/packages/types/test/views.test-d.ts), if you want to get a sense of what those look like.

here's what the LSP will complain about if you don't put anything into the `on` array:

<img width="643" alt="Screenshot 2025-06-20 at 11 10 59 AM" src="https://github.com/user-attachments/assets/be243d76-b476-400a-8443-30fd7b0fbd70" />
 
and here's what the LSP will suggest when you go to add a string:

<img width="629" alt="Screenshot 2025-06-20 at 11 11 08 AM" src="https://github.com/user-attachments/assets/8adbd0f6-2adb-4dce-b781-bbf1c549fc05" />
