### PR TITLE
chore: Deprecate `defineDocumentFunction` ability to provide `event` properties at the top level

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ import {defineBlueprint, defineDocumentFunction, defineResource} from '@sanity/b
 
 export default defineBlueprint({
   resources: [
-    defineDocumentFunction({name: 'invalidate-cache', timeout: 60, projection: '_id'}),
-    defineDocumentFunction({name: 'send-email', filter: "_type == 'press-release'"}),
     defineDocumentFunction({
       name: 'Create Fancy Report',
       src: 'functions/create-fancy-report',

--- a/src/definers.ts
+++ b/src/definers.ts
@@ -96,9 +96,10 @@ export function defineResource(resourceConfig: Partial<BlueprintResource>): Blue
 }
 
 function validateDocumentFunctionEvent(event: Partial<BlueprintFunctionResourceEvent>): BlueprintFunctionResourceEvent {
-  if (!Array.isArray(event.on)) throw new Error('`event.on` must be an array')
-  return {
+  const fullEvent = {
     on: event.on || ['publish'],
     ...event,
   }
+  if (!Array.isArray(fullEvent.on)) throw new Error('`event.on` must be an array')
+  return fullEvent
 }

--- a/src/definers.ts
+++ b/src/definers.ts
@@ -96,9 +96,13 @@ export function defineResource(resourceConfig: Partial<BlueprintResource>): Blue
 }
 
 function validateDocumentFunctionEvent(event: Partial<BlueprintFunctionResourceEvent>): BlueprintFunctionResourceEvent {
+  const cleanEvent = Object.fromEntries(
+    Object.entries(event).filter(([key]) => EVENT_KEYS.has(key as EventKey)),
+  ) as Partial<BlueprintFunctionResourceEvent>
+
   const fullEvent = {
-    on: event.on || ['publish'],
-    ...event,
+    on: cleanEvent.on || ['publish'],
+    ...cleanEvent,
   }
   if (!Array.isArray(fullEvent.on)) throw new Error('`event.on` must be an array')
   return fullEvent

--- a/src/definers.ts
+++ b/src/definers.ts
@@ -32,6 +32,13 @@ export function defineBlueprint(blueprintConfig: Partial<Blueprint> & Partial<Bl
 type EventKey = keyof BlueprintFunctionResourceEvent
 const EVENT_KEYS = new Set<EventKey>(['on', 'filter', 'projection'])
 
+export function defineDocumentFunction(functionConfig: Partial<BlueprintFunctionResource>): BlueprintFunctionResource
+
+/** @deprecated Use nested event properties under the 'event' key instead of specifying them at the top level */
+export function defineDocumentFunction(
+  functionConfig: Partial<BlueprintFunctionResource> & Partial<BlueprintFunctionResourceEvent>,
+): BlueprintFunctionResource
+
 export function defineDocumentFunction(
   functionConfig: Partial<BlueprintFunctionResource> & Partial<BlueprintFunctionResourceEvent>,
 ): BlueprintFunctionResource {

--- a/src/definers.ts
+++ b/src/definers.ts
@@ -34,7 +34,7 @@ const EVENT_KEYS = new Set<EventKey>(['on', 'filter', 'projection'])
 
 export function defineDocumentFunction(functionConfig: Partial<BlueprintFunctionResource>): BlueprintFunctionResource
 
-/** @deprecated Use nested event properties under the 'event' key instead of specifying them at the top level */
+/** @deprecated Define event properties under the 'event' key instead of specifying them at the top level */
 export function defineDocumentFunction(
   functionConfig: Partial<BlueprintFunctionResource> & Partial<BlueprintFunctionResourceEvent>,
 ): BlueprintFunctionResource
@@ -56,18 +56,20 @@ export function defineDocumentFunction(
 
   // event validation
   if (event) {
-    // check for `event` and `maybeEvent` collision
-    const invalidKeys = Object.keys(maybeEvent).filter((k) => EVENT_KEYS.has(k as EventKey))
-    if (invalidKeys.length > 0) {
-      throw new Error(`\`event\` cannot be specified with ${invalidKeys.map((k) => `\`${k}\``).join(', ')}`)
+    // `event` was specified, but event keys (aggregated in `maybeEvent`) were also specified at the top level. ambiguous and deprecated usage.
+    const duplicateKeys = Object.keys(maybeEvent).filter((k) => EVENT_KEYS.has(k as EventKey))
+    if (duplicateKeys.length > 0) {
+      throw new Error(
+        `\`event\` properties should be specified under the \`event\` key - specifying them at the top level is deprecated. The following keys were specified at the top level: ${duplicateKeys.map((k) => `\`${k}\``).join(', ')}`,
+      )
     }
-
-    if (!event.on) throw new Error('`event.on` is required')
-    if (!Array.isArray(event.on)) throw new Error('`event.on` must be an array')
+    event = validateDocumentFunctionEvent(event)
   } else {
-    const {on, filter, projection} = maybeEvent
-    if (on && !Array.isArray(on)) throw new Error('`on` must be an array')
-    event = {on: on ?? ['publish'], filter, projection}
+    event = validateDocumentFunctionEvent(maybeEvent)
+    // deprecated usage of putting event properties at the top level, warn about this.
+    console.warn(
+      '⚠️ Deprecated usage of `defineDocumentFunction`: prefer to put `event` properties under the `event` key rather than at the top level.',
+    )
   }
 
   return {
@@ -90,5 +92,13 @@ export function defineResource(resourceConfig: Partial<BlueprintResource>): Blue
     ...resourceConfig,
     type,
     name,
+  }
+}
+
+function validateDocumentFunctionEvent(event: Partial<BlueprintFunctionResourceEvent>): BlueprintFunctionResourceEvent {
+  if (!Array.isArray(event.on)) throw new Error('`event.on` must be an array')
+  return {
+    on: event.on || ['publish'],
+    ...event,
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export interface BlueprintResource {
 }
 
 export interface BlueprintFunctionResourceEvent {
-  on: [BlueprintFunctionResourceEventName, ...BlueprintFunctionResourceEventName[]]
+  on?: [BlueprintFunctionResourceEventName, ...BlueprintFunctionResourceEventName[]]
   filter?: string
   projection?: string
 }

--- a/test/definers.test.ts
+++ b/test/definers.test.ts
@@ -34,11 +34,6 @@ describe('defineFunction', () => {
     expect(() => defineDocumentFunction({name: 'test', timeout: '1'})).toThrow('`timeout` must be a number')
   })
 
-  test('should throw an error if event.on is not provided', () => {
-    // @ts-expect-error Intentionally wrong type
-    expect(() => defineDocumentFunction({name: 'test', event: {}})).toThrow('`event.on` is required')
-  })
-
   test('should throw an error if event.on is not an array', () => {
     expect(() =>
       // @ts-expect-error Intentionally wrong type
@@ -48,22 +43,22 @@ describe('defineFunction', () => {
 
   test('should throw an error if on is incorrect', () => {
     // @ts-expect-error Intentionally wrong type
-    expect(() => defineDocumentFunction({name: 'test', on: 'publish'})).toThrow('`on` must be an array')
+    expect(() => defineDocumentFunction({name: 'test', on: 'publish'})).toThrow('`event.on` must be an array')
   })
 
   test('should create the event with provided filter', () => {
-    const fn = defineDocumentFunction({name: 'test', filter: '_type == "post"'})
+    const fn = defineDocumentFunction({name: 'test', event: {filter: '_type == "post"'}})
     expect(fn.event).toEqual({on: ['publish'], filter: '_type == "post"'})
   })
 
-  test('should throw an error if event and filter are provided', () => {
+  test('should throw an error if event keys are defined using a mix of under the event object as well as at the top level', () => {
     expect(() =>
       defineDocumentFunction({
         name: 'test',
         event: {on: ['publish']},
         filter: '_type == "post"',
       }),
-    ).toThrow('`event` cannot be specified with `filter`')
+    ).toThrowError(/`event` properties should be specified under the `event` key/i)
   })
 
   test('should ignore invalid properties', () => {


### PR DESCRIPTION
A few other changes here:
- Making `on` optional; this is assumed to be `publish` in the `functions` service, FYI.
- If providing the `event` properties at the top level, TypeScript kicks in with the deprecation notice. See screenshots below.
- Removed deprecated usage from README.
- Factored `event` validation into its own method.
- Updated tests.

# Example Usage

All screenshots are from VS Code.

`event` object provided, good 👍 : 
<img width="351" height="227" alt="Screenshot 2025-08-19 at 11 39 37 AM" src="https://github.com/user-attachments/assets/0724d2f9-e437-458d-925d-14357fc50173" />

`event` properties provided to the top-level argument, without nesting under `event`, bad 👎 (note the strike-through to signify deprecation):
<img width="301" height="144" alt="Screenshot 2025-08-19 at 11 40 33 AM" src="https://github.com/user-attachments/assets/5d69cb66-e060-4e60-8f5c-ffcb3ae7bb74" />
 And if you hover over the method, you can see at the bottom you get instructions on what's wrong / how to migrate:
<img width="635" height="311" alt="Screenshot 2025-08-19 at 11 41 04 AM" src="https://github.com/user-attachments/assets/6ca9a15f-c228-4003-b808-065a8617dad2" />
