### PR TITLE
feat: Support new document change events (`create`, `delete`, `update`), plus `includeDrafts` and `includeAllVersions` filters

### DIFF
--- a/src/definers.ts
+++ b/src/definers.ts
@@ -30,7 +30,7 @@ export function defineBlueprint(blueprintConfig: Partial<Blueprint> & Partial<Bl
 }
 
 type EventKey = keyof BlueprintFunctionResourceEvent
-const EVENT_KEYS = new Set<EventKey>(['on', 'filter', 'includeDrafts', 'includeVersions', 'projection'])
+const EVENT_KEYS = new Set<EventKey>(['on', 'filter', 'includeDrafts', 'includeAllVersions', 'projection'])
 
 export function defineDocumentFunction(functionConfig: Partial<BlueprintFunctionResource>): BlueprintFunctionResource
 

--- a/src/definers.ts
+++ b/src/definers.ts
@@ -30,7 +30,7 @@ export function defineBlueprint(blueprintConfig: Partial<Blueprint> & Partial<Bl
 }
 
 type EventKey = keyof BlueprintFunctionResourceEvent
-const EVENT_KEYS = new Set<EventKey>(['on', 'filter', 'projection'])
+const EVENT_KEYS = new Set<EventKey>(['on', 'filter', 'includeDrafts', 'includeVersions', 'projection'])
 
 export function defineDocumentFunction(functionConfig: Partial<BlueprintFunctionResource>): BlueprintFunctionResource
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,10 +6,12 @@ export interface BlueprintResource {
 export interface BlueprintFunctionResourceEvent {
   on?: [BlueprintFunctionResourceEventName, ...BlueprintFunctionResourceEventName[]]
   filter?: string
+  includeDrafts?: boolean
+  includeVersions?: boolean
   projection?: string
 }
 
-type BlueprintFunctionResourceEventName = 'publish'
+type BlueprintFunctionResourceEventName = 'publish' | 'create' | 'delete' | 'update'
 
 export interface BlueprintFunctionResource extends BlueprintResource {
   type: 'sanity.function.document'

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface BlueprintFunctionResourceEvent {
   on?: [BlueprintFunctionResourceEventName, ...BlueprintFunctionResourceEventName[]]
   filter?: string
   includeDrafts?: boolean
-  includeVersions?: boolean
+  includeAllVersions?: boolean
   projection?: string
 }
 

--- a/test/definers.test.ts
+++ b/test/definers.test.ts
@@ -79,9 +79,13 @@ describe('defineFunction', () => {
   })
 
   test('should allow for creating events with explicit include* toggles', () => {
-    const fn = defineDocumentFunction({name: 'test', src: 'test.js', event: {on: ['update'], includeVersions: true, includeDrafts: true}})
+    const fn = defineDocumentFunction({
+      name: 'test',
+      src: 'test.js',
+      event: {on: ['update'], includeAllVersions: true, includeDrafts: true},
+    })
     expect(fn.event.includeDrafts).toEqual(true)
-    expect(fn.event.includeVersions).toEqual(true)
+    expect(fn.event.includeAllVersions).toEqual(true)
   })
 })
 

--- a/test/definers.test.ts
+++ b/test/definers.test.ts
@@ -46,7 +46,7 @@ describe('defineFunction', () => {
     expect(() => defineDocumentFunction({name: 'test', on: 'publish'})).toThrow('`event.on` must be an array')
   })
 
-  test('should create the event with provided filter', () => {
+  test('should create a default publish event with provided filter', () => {
     const fn = defineDocumentFunction({name: 'test', event: {filter: '_type == "post"'}})
     expect(fn.event).toEqual({on: ['publish'], filter: '_type == "post"'})
   })
@@ -71,6 +71,17 @@ describe('defineFunction', () => {
   test('should create the event with publish if not provided', () => {
     const fn = defineDocumentFunction({name: 'test', src: 'test.js'})
     expect(fn.event).toEqual({on: ['publish']})
+  })
+
+  test('should allow for creating events triggered on create, update and delete', () => {
+    const fn = defineDocumentFunction({name: 'test', src: 'test.js', event: {on: ['create', 'update', 'delete']}})
+    expect(fn.event.on).toEqual(['create', 'update', 'delete'])
+  })
+
+  test('should allow for creating events with explicit include* toggles', () => {
+    const fn = defineDocumentFunction({name: 'test', src: 'test.js', event: {on: ['update'], includeVersions: true, includeDrafts: true}})
+    expect(fn.event.includeDrafts).toEqual(true)
+    expect(fn.event.includeVersions).toEqual(true)
   })
 })
 


### PR DESCRIPTION
Should be merged and released together with https://github.com/sanity-io/runtime-cli/pull/174

Adds support for new `create`, `update` and `delete` events, and also `includeDrafts` and `includeAllVersions` filters (which default to `false`).

This resolves [RUN-699](https://linear.app/sanity/issue/RUN-699/expand-blueprint-node-with-new-document-change-event-types).