### PR TITLE
feat: Support dataset scoping of function event sources

### DIFF
--- a/src/definers.ts
+++ b/src/definers.ts
@@ -30,7 +30,7 @@ export function defineBlueprint(blueprintConfig: Partial<Blueprint> & Partial<Bl
 }
 
 type EventKey = keyof BlueprintFunctionResourceEvent
-const EVENT_KEYS = new Set<EventKey>(['on', 'filter', 'includeDrafts', 'includeAllVersions', 'projection'])
+const EVENT_KEYS = new Set<EventKey>(['on', 'filter', 'includeDrafts', 'includeAllVersions', 'projection', 'resource'])
 
 export function defineDocumentFunction(functionConfig: Partial<BlueprintFunctionResource>): BlueprintFunctionResource
 
@@ -105,5 +105,10 @@ function validateDocumentFunctionEvent(event: Partial<BlueprintFunctionResourceE
     ...cleanEvent,
   }
   if (!Array.isArray(fullEvent.on)) throw new Error('`event.on` must be an array')
+  if (fullEvent.resource) {
+    if (!fullEvent.resource.type || fullEvent.resource.type !== 'dataset') throw new Error('`event.resource.type` must be "dataset"')
+    if (!fullEvent.resource.id || fullEvent.resource.id.split('.').length !== 2)
+      throw new Error('`event.resource.id` must be in the format <projectId>.<datasetName>')
+  }
   return fullEvent
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,15 @@ export interface BlueprintFunctionResourceEvent {
   includeDrafts?: boolean
   includeAllVersions?: boolean
   projection?: string
+  /** @description The resource event source for function triggers. Only datasets are supported... for now. */
+  resource?: BlueprintFunctionResourceEventResource
+}
+
+export type BlueprintFunctionResourceEventResource = BlueprintFunctionResourceEventResourceDataset
+export interface BlueprintFunctionResourceEventResourceDataset {
+  type: 'dataset'
+  /** @description A dataset ID in the format <projectId>.<datasetName>. <datasetName> can be `*` to signify "all datasets in project with ID <projectId>." */
+  id: string
 }
 
 type BlueprintFunctionResourceEventName = 'publish' | 'create' | 'delete' | 'update'

--- a/test/definers.test.ts
+++ b/test/definers.test.ts
@@ -87,6 +87,50 @@ describe('defineFunction', () => {
     expect(fn.event.includeDrafts).toEqual(true)
     expect(fn.event.includeAllVersions).toEqual(true)
   })
+
+  test('should allow for creating events scoped to a specific dataset', () => {
+    const fn = defineDocumentFunction({
+      name: 'test',
+      src: 'test.js',
+      event: {on: ['update'], resource: {type: 'dataset', id: 'myProject.myDataset'}},
+    })
+    expect(fn.event.resource?.type).toEqual('dataset')
+    expect(fn.event.resource?.id).toEqual('myProject.myDataset')
+  })
+
+  test('should allow for creating events explicitly scoped to all datasets', () => {
+    const fn = defineDocumentFunction({
+      name: 'test',
+      src: 'test.js',
+      event: {on: ['update'], resource: {type: 'dataset', id: 'myProject.*'}},
+    })
+    expect(fn.event.resource?.type).toEqual('dataset')
+    expect(fn.event.resource?.id).toEqual('myProject.*')
+  })
+
+  test('should throw an error if event.resource.type is empty or not dataset', () => {
+    // @ts-expect-error Intentionally wrong type
+    expect(() => defineDocumentFunction({name: 'test', event: {on: ['update'], resource: {type: 'a', id: 'myProject.*'}}})).toThrow(
+      '`event.resource.type` must be "dataset"',
+    )
+    // @ts-expect-error Intentionally wrong type
+    expect(() => defineDocumentFunction({name: 'test', event: {on: ['update'], resource: {id: 'myProject.*'}}})).toThrow(
+      '`event.resource.type` must be "dataset"',
+    )
+  })
+
+  test('should throw an error if event.resource.id is invalid', () => {
+    expect(() =>
+      defineDocumentFunction({name: 'test', event: {on: ['update'], resource: {type: 'dataset', id: 'notEnoughPeriods'}}}),
+    ).toThrow('`event.resource.id` must be in the format <projectId>.<datasetName>')
+    expect(() =>
+      defineDocumentFunction({name: 'test', event: {on: ['update'], resource: {type: 'dataset', id: 'too.many.periods'}}}),
+    ).toThrow('`event.resource.id` must be in the format <projectId>.<datasetName>')
+    // @ts-expect-error Intentionally wrong type
+    expect(() => defineDocumentFunction({name: 'test', event: {on: ['update'], resource: {type: 'dataset'}}})).toThrow(
+      '`event.resource.id` must be in the format <projectId>.<datasetName>',
+    )
+  })
 })
 
 describe('defineResource', () => {


### PR DESCRIPTION
This resolves [RUN-714](https://linear.app/sanity/issue/RUN-714/resource-dataset-ts-helper-in-sanityblueprints).

DO NOT MERGE! until:

- [x] the [Content Release](https://sanity-io.slack.com/archives/CN3MWDAV7/p1758308908848369) is ready to go out
- [x] https://github.com/sanity-io/runtime-cli/pull/195 is ready to be merged
- [x] `functions` support is deployed to production

### Description

Adds the ability to specify a specific dataset to scope a function event source to.