### PR TITLE
chore: disable incremental tsbuild

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,9 +7,9 @@
     "module": "ES2022",
     "moduleResolution": "bundler",
     "skipLibCheck": true,
-    "incremental": true,
     "sourceMap": true,
     "declaration": true,
+
     // Strictest of the strict?
     "strictNullChecks": true,
     "strictFunctionTypes": true,
@@ -19,6 +19,7 @@
     "noImplicitThis": true,
     "noImplicitReturns": true,
     "noImplicitOverride": true,
+
     // Strict
     "checkJs": true,
     "isolatedModules": true,
@@ -28,6 +29,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noPropertyAccessFromIndexSignature": true,
+
     // Recommended
     "allowImportingTsExtensions": false,
     "resolveJsonModule": false,


### PR DESCRIPTION
also bring back the whitespace

`tsbuildinfo` was messing up the build after a refactor, removing it helps. but then without removing `incremental`, there is a big ol `tsconfig.tsbuildinfo` file dumped into `dist/` after every build. annoying. we don't need incremental builds for this tiny library.