### PR TITLE
 feat: support for media library asset function

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ export default defineBlueprint({
       memory: 2,
       timeout: 360,
       event: {
-        on: ['publish'],
+        on: ['create', 'update'],
         filter: "_type == 'customer'",
         projection: "{totalSpend, lastOrderDate}",
       },

--- a/src/definers/functions.ts
+++ b/src/definers/functions.ts
@@ -1,34 +1,41 @@
-import type {BlueprintFunctionResource, BlueprintFunctionResourceEvent} from '../types.js'
+import type {
+  BlueprintBaseFunctionResource,
+  BlueprintFunctionBaseResourceEvent,
+  BlueprintDocumentFunctionResource,
+  BlueprintDocumentFunctionResourceEvent,
+  BlueprintMediaLibraryAssetFunctionResource,
+  BlueprintMediaLibraryFunctionResourceEvent,
+} from '../types.js'
 
-type EventKey = keyof BlueprintFunctionResourceEvent
-const EVENT_KEYS = new Set<EventKey>(['on', 'filter', 'includeDrafts', 'includeAllVersions', 'projection', 'resource'])
+type BaseFunctionEventKey = keyof BlueprintFunctionBaseResourceEvent
+const BASE_EVENT_KEYS = new Set<BaseFunctionEventKey>(['on', 'filter', 'projection'])
+type DocumentFunctionEventKey = keyof BlueprintDocumentFunctionResourceEvent
+const DOCUMENT_EVENT_KEYS = new Set<DocumentFunctionEventKey>([
+  'includeDrafts',
+  'includeAllVersions',
+  'resource',
+  ...BASE_EVENT_KEYS.values(),
+])
+type MediaLibraryFunctionEventKey = keyof BlueprintMediaLibraryFunctionResourceEvent
+const MEDIA_LIBRARY_EVENT_KEYS = new Set<MediaLibraryFunctionEventKey>(['resource', ...BASE_EVENT_KEYS.values()])
 
-export function defineDocumentFunction(functionConfig: Partial<BlueprintFunctionResource>): BlueprintFunctionResource
+export function defineDocumentFunction(functionConfig: Partial<BlueprintDocumentFunctionResource>): BlueprintDocumentFunctionResource
 
 /** @deprecated Define event properties under the 'event' key instead of specifying them at the top level */
 export function defineDocumentFunction(
-  functionConfig: Partial<BlueprintFunctionResource> & Partial<BlueprintFunctionResourceEvent>,
-): BlueprintFunctionResource
+  functionConfig: Partial<BlueprintDocumentFunctionResource> & Partial<BlueprintDocumentFunctionResourceEvent>,
+): BlueprintDocumentFunctionResource
 
 export function defineDocumentFunction(
-  functionConfig: Partial<BlueprintFunctionResource> & Partial<BlueprintFunctionResourceEvent>,
-): BlueprintFunctionResource {
+  functionConfig: Partial<BlueprintDocumentFunctionResource> & Partial<BlueprintDocumentFunctionResourceEvent>,
+): BlueprintDocumentFunctionResource {
   let {name, src, event, timeout, memory, env, type, ...maybeEvent} = functionConfig
-
-  if (!name) throw new Error('`name` is required')
-
-  // defaults
-  if (!src) src = `functions/${name}`
   if (!type) type = 'sanity.function.document'
-
-  // type validation
-  if (memory && typeof memory !== 'number') throw new Error('`memory` must be a number')
-  if (timeout && typeof timeout !== 'number') throw new Error('`timeout` must be a number')
 
   // event validation
   if (event) {
     // `event` was specified, but event keys (aggregated in `maybeEvent`) were also specified at the top level. ambiguous and deprecated usage.
-    const duplicateKeys = Object.keys(maybeEvent).filter((k) => EVENT_KEYS.has(k as EventKey))
+    const duplicateKeys = Object.keys(maybeEvent).filter((k) => DOCUMENT_EVENT_KEYS.has(k as DocumentFunctionEventKey))
     if (duplicateKeys.length > 0) {
       throw new Error(
         `\`event\` properties should be specified under the \`event\` key - specifying them at the top level is deprecated. The following keys were specified at the top level: ${duplicateKeys.map((k) => `\`${k}\``).join(', ')}`,
@@ -44,20 +51,65 @@ export function defineDocumentFunction(
   }
 
   return {
+    ...defineFunction({
+      name,
+      src,
+      timeout,
+      memory,
+      env,
+    }),
+    type,
+    event,
+  }
+}
+
+export function defineMediaLibraryAssetFunction(
+  functionConfig: Partial<BlueprintMediaLibraryAssetFunctionResource> &
+    Pick<BlueprintMediaLibraryAssetFunctionResource, 'event'> &
+    Partial<BlueprintMediaLibraryFunctionResourceEvent>,
+): BlueprintMediaLibraryAssetFunctionResource {
+  let {name, src, event, timeout, memory, env, type} = functionConfig
+  if (!type) type = 'sanity.function.media-library.asset'
+
+  return {
+    ...defineFunction({
+      name,
+      src,
+      timeout,
+      memory,
+      env,
+    }),
+    type,
+    event: validateMediaLibraryFunctionEvent(event),
+  }
+}
+export function defineFunction(functionConfig: Partial<BlueprintBaseFunctionResource>): BlueprintBaseFunctionResource {
+  let {name, src, timeout, memory, env, type} = functionConfig
+
+  if (!name) throw new Error('`name` is required')
+
+  // defaults
+  if (!src) src = `functions/${name}`
+  if (!type) type = 'sanity.function.document'
+
+  // type validation
+  if (memory && typeof memory !== 'number') throw new Error('`memory` must be a number')
+  if (timeout && typeof timeout !== 'number') throw new Error('`timeout` must be a number')
+
+  return {
     type,
     name,
     src,
-    event,
     timeout,
     memory,
     env,
   }
 }
 
-function validateDocumentFunctionEvent(event: Partial<BlueprintFunctionResourceEvent>): BlueprintFunctionResourceEvent {
+function validateDocumentFunctionEvent(event: Partial<BlueprintDocumentFunctionResourceEvent>): BlueprintDocumentFunctionResourceEvent {
   const cleanEvent = Object.fromEntries(
-    Object.entries(event).filter(([key]) => EVENT_KEYS.has(key as EventKey)),
-  ) as Partial<BlueprintFunctionResourceEvent>
+    Object.entries(event).filter(([key]) => DOCUMENT_EVENT_KEYS.has(key as DocumentFunctionEventKey)),
+  ) as Partial<BlueprintDocumentFunctionResourceEvent>
 
   const fullEvent = {
     on: cleanEvent.on || ['publish'],
@@ -69,5 +121,18 @@ function validateDocumentFunctionEvent(event: Partial<BlueprintFunctionResourceE
     if (!fullEvent.resource.id || fullEvent.resource.id.split('.').length !== 2)
       throw new Error('`event.resource.id` must be in the format <projectId>.<datasetName>')
   }
+  return fullEvent
+}
+
+function validateMediaLibraryFunctionEvent(event: BlueprintMediaLibraryFunctionResourceEvent): BlueprintMediaLibraryFunctionResourceEvent {
+  const cleanEvent = Object.fromEntries(
+    Object.entries(event).filter(([key]) => MEDIA_LIBRARY_EVENT_KEYS.has(key as MediaLibraryFunctionEventKey)),
+  ) as BlueprintMediaLibraryFunctionResourceEvent
+
+  const fullEvent = {
+    on: cleanEvent.on || ['publish'],
+    ...cleanEvent,
+  }
+  if (!Array.isArray(fullEvent.on)) throw new Error('`event.on` must be an array')
   return fullEvent
 }

--- a/src/definers/functions.ts
+++ b/src/definers/functions.ts
@@ -1,8 +1,8 @@
 import type {
   BlueprintBaseFunctionResource,
-  BlueprintFunctionBaseResourceEvent,
   BlueprintDocumentFunctionResource,
   BlueprintDocumentFunctionResourceEvent,
+  BlueprintFunctionBaseResourceEvent,
   BlueprintMediaLibraryAssetFunctionResource,
   BlueprintMediaLibraryFunctionResourceEvent,
 } from '../types.js'

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,32 +13,46 @@ export type BlueprintCorsOriginConfig = Omit<BlueprintCorsOriginResource, 'type'
   allowCredentials?: boolean
 }
 
-export interface BlueprintFunctionResourceEvent {
+export interface BlueprintFunctionBaseResourceEvent {
   on?: [BlueprintFunctionResourceEventName, ...BlueprintFunctionResourceEventName[]]
   filter?: string
+  projection?: string
+}
+export interface BlueprintDocumentFunctionResourceEvent extends BlueprintFunctionBaseResourceEvent {
   includeDrafts?: boolean
   includeAllVersions?: boolean
-  projection?: string
-  /** @description The resource event source for function triggers. Only datasets are supported... for now. */
-  resource?: BlueprintFunctionResourceEventResource
+  resource?: BlueprintFunctionResourceEventResourceDataset
 }
+export interface BlueprintMediaLibraryFunctionResourceEvent extends BlueprintFunctionBaseResourceEvent {
+  resource: BlueprintFunctionResourceEventResourceMediaLibrary
+}
+export type BlueprintFunctionResourceEvent = BlueprintDocumentFunctionResourceEvent | BlueprintMediaLibraryFunctionResourceEvent
 
-export type BlueprintFunctionResourceEventResource = BlueprintFunctionResourceEventResourceDataset
-export interface BlueprintFunctionResourceEventResourceDataset {
+interface BlueprintFunctionResourceEventResourceDataset {
   type: 'dataset'
   /** @description A dataset ID in the format <projectId>.<datasetName>. <datasetName> can be `*` to signify "all datasets in project with ID <projectId>." */
+  id: string
+}
+interface BlueprintFunctionResourceEventResourceMediaLibrary {
+  type: 'media-library'
   id: string
 }
 
 type BlueprintFunctionResourceEventName = 'publish' | 'create' | 'delete' | 'update'
 
-export interface BlueprintFunctionResource extends BlueprintResource {
-  type: 'sanity.function.document'
+export interface BlueprintBaseFunctionResource extends BlueprintResource {
   src: string
-  event: BlueprintFunctionResourceEvent
   timeout?: number
   memory?: number
   env?: Record<string, string>
+}
+export interface BlueprintDocumentFunctionResource extends BlueprintBaseFunctionResource {
+  type: 'sanity.function.document'
+  event: BlueprintDocumentFunctionResourceEvent
+}
+export interface BlueprintMediaLibraryAssetFunctionResource extends BlueprintBaseFunctionResource {
+  type: 'sanity.function.media-library.asset'
+  event: BlueprintMediaLibraryFunctionResourceEvent
 }
 
 export interface BlueprintDocumentWebhookResource extends BlueprintResource {

--- a/test/definers.test-d.ts
+++ b/test/definers.test-d.ts
@@ -1,5 +1,5 @@
 import {describe, expectTypeOf, test} from 'vitest'
-import {defineDocumentFunction, defineMediaLibraryAssetFunction} from '../src'
+import {defineDocumentFunction} from '../src'
 
 describe('defineDocumentFunction', () => {
   test('argument types', () => {
@@ -7,5 +7,3 @@ describe('defineDocumentFunction', () => {
     expectTypeOf(defineDocumentFunction).parameter(0).toEqualTypeOf({})
   })
 })
-
-// TODO: implement type tests for backwards compatibility enforcement, but need more opinions / input from team

--- a/test/definers.test-d.ts
+++ b/test/definers.test-d.ts
@@ -1,8 +1,11 @@
-// import { assertType, describe, expect, expectTypeOf, test } from 'vitest'
-// import {
-//   defineBlueprint,
-//   defineFunction,
-//   defineResource,
-// } from '../src'
-// import type { Blueprint, BlueprintFunctionResource, BlueprintResource } from '../src'
+import {describe, expectTypeOf, test} from 'vitest'
+import {defineDocumentFunction, defineMediaLibraryAssetFunction} from '../src'
 
+describe('defineDocumentFunction', () => {
+  test('argument types', () => {
+    // can provide no arguments (not entirely true: at runtime this will throw since no name provided; we can fix this by tweaking function type signature, tho.
+    expectTypeOf(defineDocumentFunction).parameter(0).toEqualTypeOf({})
+  })
+})
+
+// TODO: implement type tests for backwards compatibility enforcement, but need more opinions / input from team


### PR DESCRIPTION
### Description

DO NOT MERGE until ready for production release (since this will be automatically released).

Resolves [RUN-777](https://linear.app/sanity/issue/RUN-777/update-blueprints-node-to-include-a-definemediafunction).

Demo of this in action [here](https://sanity-io.slack.com/archives/C07MVHJAKFU/p1761655182596719).

### Testing

- you need to use a branch of the runtime-cli: https://github.com/sanity-io/runtime-cli/pull/223
- npm link both this branch of blueprints-node _as well as_ the above runtime-cli PR branch to a blueprint project
- try to create a ML function in staging, here's a blueprint that should work (you will need to enable Media Library+ for your org and get its ID from the dashboard):

```typescript
import { defineBlueprint, defineDocumentFunction, defineMediaLibraryAssetFunction } from '@sanity/blueprints'

export default defineBlueprint({
  resources: [
    defineMediaLibraryAssetFunction({
      name: 'ml-asset',
      event: {
        on: ['create', 'update', 'delete'],
        resource: {
          type: 'media-library',
          id: 'mlFqEeKZYecz',
        }
      },
    })
  ],
})
```

For function code, I just `console.log` the `event.data`.