### PR TITLE
chore: move prepublish build run to prepare script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           cache: npm
           node-version: lts/*
       - run: npm ci
-      - run: npm run prepublishOnly
+      - run: npm run build
       - uses: actions/upload-artifact@v4
         name: Cache build output
         with:

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "coverage": "vitest --coverage",
     "lint": "biome check .",
     "lint:write": "biome check --write .",
-    "prepublishOnly": "npm run build",
+    "posttest": "npm run lint",
+    "prepare": "npm run build",
     "pretest": "npm run typecheck",
     "test": "vitest run --typecheck --reporter=verbose",
-    "posttest": "npm run lint",
     "test:watch": "vitest --typecheck --reporter=verbose",
     "typecheck": "tsc --noEmit --project tsconfig.test.json"
   },


### PR DESCRIPTION
To support using git as dependency. See description of the lifecycle hooks in npm [here](https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts).

Before, trying to use this project using git dependencies in `package.json`, won't work, since the build is not run upon install:

```console
➜ grep -B 1 blueprints package.json
  "dependencies": {
    "@sanity/blueprints": "git+ssh://git@github.com:sanity-io/blueprints-node.git"
➜ npm i

added 1 package, and audited 2 packages in 3s

found 0 vulnerabilities
➜ l node_modules/@sanity/blueprints/dist
ls: node_modules/@sanity/blueprints/dist: No such file or directory
```

After, using this branch in a project:

```console
➜ grep -B 1 blueprints package.json
  "dependencies": {
    "@sanity/blueprints": "git+ssh://git@github.com:sanity-io/blueprints-node.git#prepare"
➜ npm i

added 1 package, and audited 2 packages in 4s

found 0 vulnerabilities
➜ l node_modules/@sanity/blueprints/dist
total 48
drwxr-xr-x@  9 filmaj  staff   288B Oct 29 14:06 .
drwxr-xr-x@  6 filmaj  staff   192B Oct 29 14:06 ..
drwxr-xr-x@ 11 filmaj  staff   352B Oct 29 14:06 definers
-rw-r--r--@  1 filmaj  staff   152B Oct 29 14:06 index.d.ts
-rw-r--r--@  1 filmaj  staff   185B Oct 29 14:06 index.js
-rw-r--r--@  1 filmaj  staff   190B Oct 29 14:06 index.js.map
-rw-r--r--@  1 filmaj  staff   1.7K Oct 29 14:06 types.d.ts
-rw-r--r--@  1 filmaj  staff    44B Oct 29 14:06 types.js
-rw-r--r--@  1 filmaj  staff   102B Oct 29 14:06 types.js.map
```

I want to create a little demo project / scaffold using branches of this repo (and the runtime-cli repo too!) but that's hard to do without `prepare` being defined.