### PR TITLE
fix: Move webhook types into types.ts file

### DIFF
--- a/src/definers/webhooks.ts
+++ b/src/definers/webhooks.ts
@@ -1,22 +1,4 @@
-import type {BlueprintResource} from '../types'
-
-export interface BlueprintDocumentWebhookResource extends BlueprintResource {
-  type: 'sanity.project.webhook'
-  project?: string
-  displayName?: string
-  description?: string | null
-  url: string
-  on: string[]
-  filter?: string | null
-  projection?: string | null
-  status?: 'enabled' | 'disabled'
-  httpMethod?: 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'GET'
-  headers?: Record<string, string>
-  includeDrafts?: boolean
-  secret?: string | null
-  dataset?: string
-}
-export type BlueprintDocumentWebhookConfig = Omit<BlueprintDocumentWebhookResource, 'type'>
+import type {BlueprintDocumentWebhookConfig, BlueprintDocumentWebhookResource} from '../types'
 
 export function defineDocumentWebhook(parameters: BlueprintDocumentWebhookConfig): BlueprintDocumentWebhookResource {
   const errors: string[] = []

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,24 @@ export interface BlueprintFunctionResource extends BlueprintResource {
   env?: Record<string, string>
 }
 
+export interface BlueprintDocumentWebhookResource extends BlueprintResource {
+  type: 'sanity.project.webhook'
+  project?: string
+  displayName?: string
+  description?: string | null
+  url: string
+  on: string[]
+  filter?: string | null
+  projection?: string | null
+  status?: 'enabled' | 'disabled'
+  httpMethod?: 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'GET'
+  headers?: Record<string, string>
+  includeDrafts?: boolean
+  secret?: string | null
+  dataset?: string
+}
+export type BlueprintDocumentWebhookConfig = Omit<BlueprintDocumentWebhookResource, 'type'>
+
 export interface BlueprintOutput {
   name: string
   value: string


### PR DESCRIPTION
### Description

Cleaning up types as they should all go in types.ts for export
