### PR TITLE
fix: update function event.projection type to include wrapped curlies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ export default defineBlueprint({
         currency: 'USD',
       },
     }),
-
-    const webhookResource = defineDocumentWebhook({
+    defineDocumentWebhook({
       name: 'notification-webhook',
       url: 'http://api.yourdomain.com/notifications/sanity',
       on: ['create'],

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ export type BlueprintCorsOriginConfig = Omit<BlueprintCorsOriginResource, 'type'
 export interface BlueprintFunctionBaseResourceEvent {
   on?: [BlueprintFunctionResourceEventName, ...BlueprintFunctionResourceEventName[]]
   filter?: string
-  projection?: string
+  projection?: `{${string}}`
 }
 export interface BlueprintDocumentFunctionResourceEvent extends BlueprintFunctionBaseResourceEvent {
   includeDrafts?: boolean

--- a/test/definers/readme.test.ts
+++ b/test/definers/readme.test.ts
@@ -1,15 +1,10 @@
 import {describe, expect, test} from 'vitest'
-import {defineBlueprint, defineDocumentFunction, defineResource} from '../../src/index.js'
+import {defineBlueprint, defineDocumentFunction, defineDocumentWebhook} from '../../src/index.js'
 
 describe('README example', () => {
   test('should be valid', () => {
     const readmeExample = defineBlueprint({
       resources: [
-        defineDocumentFunction({name: 'invalidate-cache', projection: '_id'}),
-        defineDocumentFunction({
-          name: 'send-email',
-          filter: "_type == 'press-release'",
-        }),
         defineDocumentFunction({
           name: 'Create Fancy Report',
           src: 'functions/create-fancy-report',
@@ -18,13 +13,18 @@ describe('README example', () => {
           event: {
             on: ['publish'],
             filter: "_type == 'customer'",
-            projection: 'totalSpend, lastOrderDate',
+            projection: '{totalSpend, lastOrderDate}',
           },
           env: {
             currency: 'USD',
           },
         }),
-        defineResource({name: 'test-resource', type: 'test'}),
+        defineDocumentWebhook({
+          name: 'notification-webhook',
+          url: 'http://api.yourdomain.com/notifications/sanity',
+          on: ['create'],
+          dataset: 'production',
+        }),
       ],
     })
 
@@ -38,24 +38,6 @@ describe('README example', () => {
     expect(blueprint.resources).toEqual([
       {
         type: 'sanity.function.document',
-        name: 'invalidate-cache',
-        src: 'functions/invalidate-cache',
-        event: {on: ['publish'], projection: '_id'},
-        memory: undefined,
-        timeout: undefined,
-        env: undefined,
-      },
-      {
-        type: 'sanity.function.document',
-        name: 'send-email',
-        src: 'functions/send-email',
-        event: {on: ['publish'], filter: "_type == 'press-release'"},
-        memory: undefined,
-        timeout: undefined,
-        env: undefined,
-      },
-      {
-        type: 'sanity.function.document',
         name: 'Create Fancy Report',
         src: 'functions/create-fancy-report',
         memory: 2,
@@ -63,15 +45,19 @@ describe('README example', () => {
         event: {
           on: ['publish'],
           filter: "_type == 'customer'",
-          projection: 'totalSpend, lastOrderDate',
+          projection: '{totalSpend, lastOrderDate}',
         },
         env: {
           currency: 'USD',
         },
       },
       {
-        type: 'test',
-        name: 'test-resource',
+        dataset: 'production',
+        displayName: 'notification-webhook',
+        name: 'notification-webhook',
+        on: ['create'],
+        type: 'sanity.project.webhook',
+        url: 'http://api.yourdomain.com/notifications/sanity',
       },
     ])
   })


### PR DESCRIPTION
WDYT? This came from a suggestion from @bobinska-dev in RUN-757.

Is this considered a breaking change? I guess not since NOT wrapping this in curlies yields a runtime error, anyways?

Before, invalid projection (missing curlies), no complaints:

<img width="422" height="255" alt="Screenshot 2025-11-05 at 1 30 49 PM" src="https://github.com/user-attachments/assets/5c7cb5ea-11fb-4d52-9e3c-58c6cbcc6a80" />

After, invalid projection (missing curlies), author-time complaints:

<img width="955" height="324" alt="Screenshot 2025-11-05 at 1 31 29 PM" src="https://github.com/user-attachments/assets/5d19703a-46cc-414f-bf5a-7c01e8423472" />
