### PR TITLE
fix: Ensure webhooks types match expectations in provider

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -55,21 +55,24 @@ export interface BlueprintMediaLibraryAssetFunctionResource extends BlueprintBas
   event: BlueprintMediaLibraryFunctionResourceEvent
 }
 
+export type WebhookTrigger = 'create' | 'update' | 'delete'
 export interface BlueprintDocumentWebhookResource extends BlueprintResource {
   type: 'sanity.project.webhook'
   project?: string
   displayName?: string
   description?: string | null
   url: string
-  on: string[]
-  filter?: string | null
-  projection?: string | null
+  on: WebhookTrigger[]
+  filter?: string
+  projection?: string
   status?: 'enabled' | 'disabled'
   httpMethod?: 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'GET'
   headers?: Record<string, string>
   includeDrafts?: boolean
-  secret?: string | null
+  includeAllVersions?: boolean
+  secret?: string
   dataset?: string
+  apiVersion?: string
 }
 export type BlueprintDocumentWebhookConfig = Omit<BlueprintDocumentWebhookResource, 'type'>
 

--- a/test/definers/webhooks.test.ts
+++ b/test/definers/webhooks.test.ts
@@ -61,6 +61,7 @@ describe('defineDocumentWebhook', () => {
       defineDocumentWebhook({
         name: 'webhook-name',
         url: 'http://localhost/',
+        // @ts-expect-error invalid value for testing
         on: ['invalid'],
       }),
     ).toThrow(/Invalid event types: invalid/)


### PR DESCRIPTION
### Description

This fix cleans up some mismatches in the types between the webhook provider and these definer functions.