### PR TITLE
fix: Remove unused permission type

### DIFF
--- a/src/definers/roles.ts
+++ b/src/definers/roles.ts
@@ -3,7 +3,6 @@ import type {BlueprintResource} from '../types'
 export interface RolePermission {
   name: string // Required: predefined permission name (e.g., 'sanity-all-documents')
   action: string // Required: permission action (e.g., 'read', 'mode')
-  type?: string // Optional: internal use only, not sent to API
   params?: Record<string, unknown> // Optional: additional parameters for the permission
 }
 


### PR DESCRIPTION
### Description

Forgot to remove this in the initial PR. Checked with Vincent and it's not being used and can be removed.