### PR TITLE
feat: Add ownershipAction lifecycle property

### DIFF
--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -1,7 +1,15 @@
 export type BlueprintResourceDeletionPolicy = 'allow' | 'retain' | 'replace' | 'protect'
 
+export type BlueprintOwnershipAttachAction = {
+  type: 'attach'
+  id: string
+}
+export type BlueprintOwnershipAction = BlueprintOwnershipAttachAction
+
 export interface BlueprintResourceLifecycle {
   deletionPolicy?: BlueprintResourceDeletionPolicy
+
+  ownershipAction?: BlueprintOwnershipAction
 }
 
 /**

--- a/src/validation/resources.ts
+++ b/src/validation/resources.ts
@@ -30,6 +30,27 @@ export function validateResource(resourceConfig: unknown): BlueprintError[] {
           errors.push({type: 'invalid_value', message: '`deletionPolicy` must be one of allow, retain, replace, protect'})
         }
       }
+
+      if ('ownershipAction' in resourceConfig.lifecycle) {
+        const ownershipAction = resourceConfig.lifecycle.ownershipAction
+        if (typeof ownershipAction !== 'object' || ownershipAction === null) {
+          errors.push({type: 'invalid_type', message: '`ownershipAction` must be an object'})
+        } else if (!('type' in ownershipAction)) {
+          errors.push({type: 'missing_parameter', message: '`ownershipAction.type` is required'})
+        } else if (typeof ownershipAction.type !== 'string') {
+          errors.push({type: 'invalid_type', message: '`ownershipAction.type` must be a string'})
+        } else if (!['attach'].includes(ownershipAction.type)) {
+          errors.push({type: 'invalid_value', message: '`ownershipAction.type` must be attach'})
+        } else {
+          if (ownershipAction.type === 'attach') {
+            if (!('id' in ownershipAction)) {
+              errors.push({type: 'missing_parameter', message: '`ownershipAction.id` is required for attach'})
+            } else if (typeof ownershipAction.id !== 'string') {
+              errors.push({type: 'invalid_type', message: '`ownershipAction.id` must be a string'})
+            }
+          }
+        }
+      }
     }
   }
 

--- a/test/unit/validation/resources.test.ts
+++ b/test/unit/validation/resources.test.ts
@@ -52,4 +52,49 @@ describe('validateResource', () => {
     const errors = validateResource({name: 'test', type: 'test', lifecycle: {deletionPolicy: 'invalid'}})
     expect(errors).toContainEqual({type: 'invalid_value', message: '`deletionPolicy` must be one of allow, retain, replace, protect'})
   })
+
+  test('should return an error if lifecycle.ownershipAction is not an object', () => {
+    const errors = validateResource({name: 'test', type: 'test', lifecycle: {ownershipAction: 1}})
+    expect(errors).toContainEqual({type: 'invalid_type', message: '`ownershipAction` must be an object'})
+  })
+
+  test('should return an error if lifecycle.ownershipAction has no type', () => {
+    const errors = validateResource({name: 'test', type: 'test', lifecycle: {ownershipAction: {}}})
+    expect(errors).toContainEqual({type: 'missing_parameter', message: '`ownershipAction.type` is required'})
+  })
+
+  test('should return an error if lifecycle.ownershipAction.type is not a string', () => {
+    const errors = validateResource({name: 'test', type: 'test', lifecycle: {ownershipAction: {type: 1}}})
+    expect(errors).toContainEqual({type: 'invalid_type', message: '`ownershipAction.type` must be a string'})
+  })
+
+  test('should return an error if lifecycle.ownershipAction.type is not valid', () => {
+    const errors = validateResource({name: 'test', type: 'test', lifecycle: {ownershipAction: {type: 'invalid'}}})
+    expect(errors).toContainEqual({type: 'invalid_value', message: '`ownershipAction.type` must be attach'})
+  })
+
+  test('should return an error if lifecycle.ownershipAction has no id', () => {
+    const errors = validateResource({name: 'test', type: 'test', lifecycle: {ownershipAction: {type: 'attach'}}})
+    expect(errors).toContainEqual({type: 'missing_parameter', message: '`ownershipAction.id` is required for attach'})
+  })
+
+  test('should return an error if lifecycle.ownershipAction.id is not a string', () => {
+    const errors = validateResource({name: 'test', type: 'test', lifecycle: {ownershipAction: {type: 'attach', id: 1}}})
+    expect(errors).toContainEqual({type: 'invalid_type', message: '`ownershipAction.id` must be a string'})
+  })
+
+  test('should return no errors for a valid resource', () => {
+    const errors = validateResource({
+      name: 'test',
+      type: 'test',
+      lifecycle: {
+        deletionPolicy: 'allow',
+        ownershipAction: {
+          type: 'attach',
+          id: 'test-id',
+        },
+      },
+    })
+    expect(errors).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
### Description

Adds types and validation for the new ownershipAction property in the resource lifecycle.

### Testing

Added new tests for validation logic.
