### PR TITLE
fix: Allow project in function resource and make webhook dataset required

### DIFF
--- a/src/definers/functions.ts
+++ b/src/definers/functions.ts
@@ -65,7 +65,7 @@ export function defineDocumentFunction(
 export function defineDocumentFunction(
   functionConfig: Partial<BlueprintDocumentFunctionResource> & RequiredFunctionProperties & Partial<BlueprintDocumentFunctionResourceEvent>,
 ): BlueprintDocumentFunctionResource {
-  let {name, src, event, timeout, memory, env, type, robotToken, ...maybeEvent} = functionConfig
+  let {name, src, event, timeout, memory, env, type, robotToken, project, ...maybeEvent} = functionConfig
   if (!type) type = 'sanity.function.document'
 
   // event validation and normalization
@@ -96,6 +96,7 @@ export function defineDocumentFunction(
         memory,
         env,
         robotToken,
+        project,
       },
       {
         skipValidation: true, // already done below
@@ -139,7 +140,7 @@ export function defineMediaLibraryAssetFunction(
     Pick<BlueprintMediaLibraryAssetFunctionResource, 'event'> &
     Partial<BlueprintMediaLibraryFunctionResourceEvent>,
 ): BlueprintMediaLibraryAssetFunctionResource {
-  let {name, src, event, timeout, memory, env, type, robotToken} = functionConfig
+  let {name, src, event, timeout, memory, env, type, robotToken, project} = functionConfig
   if (!type) type = 'sanity.function.media-library.asset'
 
   const functionResource: BlueprintMediaLibraryAssetFunctionResource = {
@@ -151,6 +152,7 @@ export function defineMediaLibraryAssetFunction(
         memory,
         env,
         robotToken,
+        project,
       },
       {
         skipValidation: true, // already done below
@@ -241,7 +243,7 @@ export function defineFunction(
   functionConfig: Partial<BlueprintBaseFunctionResource> & RequiredFunctionProperties,
   options?: {skipValidation?: boolean},
 ): BlueprintBaseFunctionResource {
-  let {name, src, timeout, memory, env, type, robotToken} = functionConfig
+  let {name, src, timeout, memory, env, type, robotToken, project} = functionConfig
 
   // defaults
   if (!src) src = `functions/${name}`
@@ -255,6 +257,7 @@ export function defineFunction(
     memory,
     env,
     robotToken,
+    project,
   }
 
   if (options?.skipValidation !== true) runValidation(() => validateFunction(functionResource))

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -76,6 +76,12 @@ export interface BlueprintBaseFunctionResource extends BlueprintResource {
   env?: Record<string, string>
   /** Token provided during function invocation */
   robotToken?: string
+
+  /**
+   * The project ID of the project that contains your function.
+   *
+   * The `project` attribute must be defined if your blueprint is scoped to an organization. */
+  project?: string
 }
 /** A function resource triggered by document events in Sanity datasets */
 export interface BlueprintDocumentFunctionResource extends BlueprintBaseFunctionResource {

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -19,7 +19,7 @@ export interface BlueprintDocumentWebhookResource extends BlueprintResource {
   includeDrafts?: boolean
   includeAllVersions?: boolean
   secret?: string
-  dataset?: string
+  dataset: string
   apiVersion: string
 }
 

--- a/test/unit/definers/functions.test.ts
+++ b/test/unit/definers/functions.test.ts
@@ -92,6 +92,16 @@ describe('defineDocumentFunction', () => {
       expect(fn.event.resource?.type).toEqual('dataset')
       expect(fn.event.resource?.id).toEqual('myProject.*')
     })
+
+    test('should allow for creating a function in a specific project', () => {
+      const fn = fns.defineDocumentFunction({
+        name: 'test',
+        src: 'test.js',
+        event: {on: ['update']},
+        project: 'projectId',
+      })
+      expect(fn.project).toEqual('projectId')
+    })
   })
 
   describe('sad paths', () => {
@@ -144,6 +154,16 @@ describe('defineMediaLibraryAssetFunction', () => {
         event: {on: ['update'], includeDrafts: false, resource},
       })
       expect(fn.event.includeDrafts).toEqual(false)
+    })
+
+    test('should allow for creating functions in a specific project', () => {
+      const fn = fns.defineMediaLibraryAssetFunction({
+        name: 'test',
+        src: 'test.js',
+        event: {on: ['update'], resource},
+        project: 'projectId',
+      })
+      expect(fn.project).toEqual('projectId')
     })
   })
 


### PR DESCRIPTION
### Description

* When defining a function in an org blueprint, we need to specify the project where the function should live.
* Webhook validation forces us to specify a dataset so make it required