### PR TITLE
fix: Ensure resources have proper lifecycle type

### DIFF
--- a/src/types/datasets.ts
+++ b/src/types/datasets.ts
@@ -1,4 +1,4 @@
-import type {BlueprintResource} from '../index.js'
+import type {BlueprintProjectResourceLifecycle, BlueprintResource} from '../index.js'
 
 export type AclMode = 'public' | 'private' | 'custom'
 
@@ -6,7 +6,7 @@ export type AclMode = 'public' | 'private' | 'custom'
  * Represents a Dataset resource.
  * @see https://www.sanity.io/docs/content-lake/datasets
  */
-export interface BlueprintDatasetResource extends BlueprintResource {
+export interface BlueprintDatasetResource extends BlueprintResource<BlueprintProjectResourceLifecycle> {
   type: 'sanity.project.dataset'
   /** The name of the dataset. Must be unique within a project. */
   datasetName: string

--- a/src/types/robots.ts
+++ b/src/types/robots.ts
@@ -1,4 +1,4 @@
-import type {BlueprintResource} from './resources'
+import type {BlueprintProjectResourceLifecycle, BlueprintResource} from './resources'
 
 /** Resource types that robots can be attached to. */
 export type RobotResourceType = 'organization' | 'project'
@@ -16,7 +16,7 @@ export interface RobotMembership {
  * A robot that provides a token for automated access.
  * @see https://www.sanity.io/docs/content-lake/http-auth#k4c21d7b829fe
  */
-export interface BlueprintRobotResource extends BlueprintResource {
+export interface BlueprintRobotResource extends BlueprintResource<BlueprintProjectResourceLifecycle> {
   type: 'sanity.access.robot'
   /** A descriptive label for the robot and its use case */
   label: string

--- a/src/types/roles.ts
+++ b/src/types/roles.ts
@@ -1,4 +1,4 @@
-import type {BlueprintResource} from '../index.js'
+import type {BlueprintProjectResourceLifecycle, BlueprintResource} from '../index.js'
 
 /**
  * A permission definition for a role.
@@ -15,7 +15,7 @@ export interface RolePermission {
 /**
  * Configuration for a custom role.
  */
-export interface BlueprintRoleConfig extends Omit<BlueprintResource, 'type'> {
+export interface BlueprintRoleConfig extends Omit<BlueprintResource<BlueprintProjectResourceLifecycle>, 'type'> {
   title: string
   description?: string
   appliesToUsers: boolean
@@ -26,7 +26,7 @@ export interface BlueprintRoleConfig extends Omit<BlueprintResource, 'type'> {
 /**
  * A custom role resource
  */
-export interface BlueprintRoleResource extends BlueprintRoleConfig, BlueprintResource {
+export interface BlueprintRoleResource extends BlueprintRoleConfig, BlueprintResource<BlueprintProjectResourceLifecycle> {
   type: 'sanity.access.role'
 }
 

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -1,10 +1,10 @@
-import type {BlueprintResource} from '../index.js'
+import type {BlueprintProjectResourceLifecycle, BlueprintResource} from '../index.js'
 
 /** Types of events that can trigger a webhook */
 export type WebhookTrigger = 'create' | 'update' | 'delete'
 
 /** A webhook resource definition */
-export interface BlueprintDocumentWebhookResource extends BlueprintResource {
+export interface BlueprintDocumentWebhookResource extends BlueprintResource<BlueprintProjectResourceLifecycle> {
   type: 'sanity.project.webhook'
   project?: string
   displayName?: string

--- a/test/unit/definers/dataset.test.ts
+++ b/test/unit/definers/dataset.test.ts
@@ -38,6 +38,23 @@ describe('defineDataset', () => {
     expect(datasetResource.lifecycle?.deletionPolicy).toStrictEqual('allow')
   })
 
+  test('should accept a valid configuration with an attach lifecycle', () => {
+    const datasetResource = datasets.defineDataset({
+      name: 'dataset-name',
+      aclMode: 'public',
+
+      lifecycle: {
+        ownershipAction: {
+          type: 'attach',
+          projectId: 'test-project',
+          id: 'production',
+        },
+      },
+    })
+
+    expect(datasetResource.lifecycle?.ownershipAction?.projectId).toStrictEqual('test-project')
+  })
+
   test('should throw if validateDataset returns an error', () => {
     const spy = vi.spyOn(index, 'validateDataset').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
     expect(() =>

--- a/test/unit/definers/robots.test.ts
+++ b/test/unit/definers/robots.test.ts
@@ -50,6 +50,29 @@ describe('defineRobot', () => {
     expect(datasetResource.lifecycle?.deletionPolicy).toStrictEqual('allow')
   })
 
+  test('should accept a valid configuration with an attach lifecycle', () => {
+    const datasetResource = robots.defineRobot({
+      name: 'robot-name',
+      memberships: [
+        {
+          resourceType: 'project',
+          resourceId: 'test-project',
+          roleNames: ['test-role'],
+        },
+      ],
+
+      lifecycle: {
+        ownershipAction: {
+          type: 'attach',
+          projectId: 'test-project',
+          id: 'robot-id',
+        },
+      },
+    })
+
+    expect(datasetResource.lifecycle?.ownershipAction?.projectId).toStrictEqual('test-project')
+  })
+
   test('should throw if validateRobot returns an error', () => {
     const spy = vi.spyOn(index, 'validateRobot').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
     expect(() =>

--- a/test/unit/definers/roles.test.ts
+++ b/test/unit/definers/roles.test.ts
@@ -53,6 +53,31 @@ describe('defineRole', () => {
 
     expect(roleResource.lifecycle?.deletionPolicy).toStrictEqual('allow')
   })
+
+  test('should accept a valid configuration with an attach lifecycle', () => {
+    const roleResource = roles.defineRole({
+      name: 'role-name',
+      title: 'Role Name',
+      appliesToRobots: true,
+      appliesToUsers: true,
+      permissions: [
+        {
+          name: 'role-name-read',
+          action: 'read',
+        },
+      ],
+
+      lifecycle: {
+        ownershipAction: {
+          type: 'attach',
+          projectId: 'test-project',
+          id: 'role-name',
+        },
+      },
+    })
+
+    expect(roleResource.lifecycle?.ownershipAction?.projectId).toStrictEqual('test-project')
+  })
 })
 
 describe('defineProjectRole', () => {
@@ -94,5 +119,30 @@ describe('defineProjectRole', () => {
     })
 
     expect(roleResource.lifecycle?.deletionPolicy).toStrictEqual('allow')
+  })
+
+  test('should accept a valid configuration with an attach lifecycle', () => {
+    const roleResource = roles.defineProjectRole('test-project', {
+      name: 'role-name',
+      title: 'Role Name',
+      appliesToRobots: true,
+      appliesToUsers: true,
+      permissions: [
+        {
+          name: 'role-name-read',
+          action: 'read',
+        },
+      ],
+
+      lifecycle: {
+        ownershipAction: {
+          type: 'attach',
+          projectId: 'test-project',
+          id: 'role-name',
+        },
+      },
+    })
+
+    expect(roleResource.lifecycle?.ownershipAction?.projectId).toStrictEqual('test-project')
   })
 })

--- a/test/unit/definers/webhooks.test.ts
+++ b/test/unit/definers/webhooks.test.ts
@@ -50,6 +50,26 @@ describe('defineDocumentWebhook', () => {
     expect(webhookResource.lifecycle?.deletionPolicy).toStrictEqual('allow')
   })
 
+  test('should accept a valid configuration with an attach lifecycle', () => {
+    const webhookResource = webhooks.defineDocumentWebhook({
+      name: 'webhook-name',
+      url: 'http://localhost/',
+      on: ['create'],
+      dataset: 'abcdefg',
+      apiVersion: 'vX',
+
+      lifecycle: {
+        ownershipAction: {
+          type: 'attach',
+          projectId: 'test-project',
+          id: 'webhook-id',
+        },
+      },
+    })
+
+    expect(webhookResource.lifecycle?.ownershipAction?.projectId).toStrictEqual('test-project')
+  })
+
   test('displayName should default to name if not provided', () => {
     const webhookResource = webhooks.defineDocumentWebhook({
       name: 'webhook-name',


### PR DESCRIPTION
### Description

When trying to attach datasets, robots, roles and webhooks you need to specify a projectId. This PR make the types reflect that.