### PR TITLE
feat: Support for references

### DIFF
--- a/src/definers/projects.ts
+++ b/src/definers/projects.ts
@@ -1,4 +1,11 @@
-import {type BlueprintProjectConfig, type BlueprintProjectResource, validateProject} from '../index.js'
+import {
+  type BlueprintCrossStackReferenceConfig,
+  type BlueprintProjectConfig,
+  type BlueprintProjectResource,
+  type BlueprintResource,
+  referenceResource,
+  validateProject,
+} from '../index.js'
 import {runValidation} from '../utils/validation.js'
 
 /**
@@ -15,7 +22,7 @@ import {runValidation} from '../utils/validation.js'
  * @beta Deploying Projects via Blueprints is experimental. This feature is stabilizing but may still be subject to breaking changes.
  * @category Definers
  * @expandType BlueprintProjectConfig
- * @returns The robot token resource
+ * @returns The project resource
  * @hidden
  */
 export function defineProject(parameters: BlueprintProjectConfig): BlueprintProjectResource {
@@ -31,4 +38,25 @@ export function defineProject(parameters: BlueprintProjectConfig): BlueprintProj
   runValidation(() => validateProject(projectResource))
 
   return projectResource
+}
+
+/**
+ * Creates a reference to a project in another stack.
+ *
+ * ```ts
+ * referenceProject({
+ *   name: 'editorial-project',
+ *   stack: 'editorial',
+ * })
+ * ```
+ *
+ * @param params The parameters for referencing the project
+ * @public
+ * @beta Referencing Projects via Blueprints is experimental. This feature is stabilizing but may still be subject to breaking changes.
+ * @category Referencers
+ * @returns The project reference
+ * @hidden
+ */
+export function referenceProject({name, stack, localName}: BlueprintCrossStackReferenceConfig): BlueprintResource {
+  return referenceResource({name, stack, localName, type: 'sanity.project'})
 }

--- a/src/definers/resources.ts
+++ b/src/definers/resources.ts
@@ -42,7 +42,7 @@ export function defineResource(resourceConfig: Partial<BlueprintResource>): Blue
  * Creates a reference to a resource in another stack
  * @param params The parameters for referencing the resource
  * @category Definers
- * @expandType BlueprintResource
+ * @expandType BlueprintCrossStackReferenceResourceConfig
  * @internal
  */
 export function referenceResource({name, type, stack, localName}: BlueprintCrossStackReferenceResourceConfig): BlueprintResource {

--- a/src/definers/resources.ts
+++ b/src/definers/resources.ts
@@ -1,4 +1,4 @@
-import {assertResource, type BlueprintResource} from '../index.js'
+import {assertResource, type BlueprintCrossStackReferenceResourceConfig, type BlueprintResource} from '../index.js'
 
 /*
  * FUTURE example (move below @example when ready)
@@ -36,4 +36,25 @@ export function defineResource(resourceConfig: Partial<BlueprintResource>): Blue
   assertResource(resource)
 
   return resource
+}
+
+/**
+ * Creates a reference to a resource in another stack
+ * @param params The parameters for referencing the project
+ * @category Definers
+ * @expandType BlueprintResource
+ * @internal
+ */
+export function referenceResource({name, type, stack, localName}: BlueprintCrossStackReferenceResourceConfig): BlueprintResource {
+  return {
+    type,
+    name: localName || name,
+    lifecycle: {
+      ownershipAction: {
+        type: 'reference',
+        stack,
+        name,
+      },
+    },
+  }
 }

--- a/src/definers/resources.ts
+++ b/src/definers/resources.ts
@@ -46,15 +46,19 @@ export function defineResource(resourceConfig: Partial<BlueprintResource>): Blue
  * @internal
  */
 export function referenceResource({name, type, stack, localName}: BlueprintCrossStackReferenceResourceConfig): BlueprintResource {
-  return {
+  const resource = {
     type,
     name: localName || name,
     lifecycle: {
       ownershipAction: {
-        type: 'reference',
+        type: 'reference' as const,
         stack,
         name,
       },
     },
   }
+
+  assertResource(resource)
+
+  return resource
 }

--- a/src/definers/resources.ts
+++ b/src/definers/resources.ts
@@ -40,7 +40,7 @@ export function defineResource(resourceConfig: Partial<BlueprintResource>): Blue
 
 /**
  * Creates a reference to a resource in another stack
- * @param params The parameters for referencing the project
+ * @param params The parameters for referencing the resource
  * @category Definers
  * @expandType BlueprintResource
  * @internal

--- a/src/definers/robotTokens.ts
+++ b/src/definers/robotTokens.ts
@@ -1,4 +1,11 @@
-import {type BlueprintRobotTokenConfig, type BlueprintRobotTokenResource, validateRobotToken} from '../index.js'
+import {
+  type BlueprintCrossStackReferenceConfig,
+  type BlueprintResource,
+  type BlueprintRobotTokenConfig,
+  type BlueprintRobotTokenResource,
+  referenceResource,
+  validateRobotToken,
+} from '../index.js'
 import {runValidation} from '../utils/validation.js'
 
 /*
@@ -53,4 +60,25 @@ export function defineRobotToken(parameters: BlueprintRobotTokenConfig): Bluepri
   runValidation(() => validateRobotToken(robotResource))
 
   return robotResource
+}
+
+/**
+ * Creates a reference to a robot token in another stack.
+ *
+ * ```ts
+ * referenceRobotToken({
+ *   name: 'editor-token',
+ *   stack: 'editorial',
+ * })
+ * ```
+ *
+ * @public
+ * @beta Referencing Robot Tokens via Blueprints is experimental. This feature is stabilizing but may still be subject to breaking changes.
+ * @category Referencers
+ * @expandType BlueprintCrossStackReferenceConfig
+ * @param params The parameters for referencing the robot token
+ * @returns The robot token reference
+ */
+export function referenceRobotToken({name, stack, localName}: BlueprintCrossStackReferenceConfig): BlueprintResource {
+  return referenceResource({name, stack, localName, type: 'sanity.access.robot'})
 }

--- a/src/definers/roles.ts
+++ b/src/definers/roles.ts
@@ -1,7 +1,10 @@
 import {
+  type BlueprintCrossStackReferenceConfig,
   type BlueprintProjectRoleResource,
+  type BlueprintResource,
   type BlueprintRoleConfig,
   type BlueprintRoleResource,
+  referenceResource,
   validateProjectRole,
   validateRole,
 } from '../index.js'
@@ -133,4 +136,25 @@ export function defineProjectRole(projectId: string, parameters: BlueprintRoleCo
   runValidation(() => validateProjectRole(projectRoleResource))
 
   return projectRoleResource
+}
+
+/**
+ * Creates a reference to a role in another stack.
+ *
+ * ```ts
+ * referenceRole({
+ *   name: 'editor-role',
+ *   stack: 'editorial',
+ * })
+ * ```
+ *
+ * @public
+ * @beta Referencing Roles via Blueprints is experimental. This feature is stabilizing but may still be subject to breaking changes.
+ * @category Referencers
+ * @expandType BlueprintCrossStackReferenceConfig
+ * @param params The parameters for referencing the role
+ * @returns The role reference
+ */
+export function referenceRole({name, stack, localName}: BlueprintCrossStackReferenceConfig): BlueprintResource {
+  return referenceResource({name, stack, localName, type: 'sanity.access.role'})
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,10 @@
  * @categoryDescription Definers
  * These functions are used to define resources in a Blueprint.
  */
+/**
+ * @categoryDescription Referencers
+ * These functions are used to reference resources in another Blueprint.
+ */
 export * from './definers/blueprints.js'
 export * from './definers/cors.js'
 export * from './definers/datasets.js'

--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -26,11 +26,24 @@ export interface BlueprintOwnershipDetachAction {
   type: 'detach'
 }
 /**
+ * An ownership action that will cause the resource to be read during deployment so it can be referenced
+ * by other resources. Note that referenced resources must be in the same project or organization as the
+ * current stack.
+ * @category Blueprint Internals
+ */
+export interface BlueprintOwnershipReferenceAction {
+  type: 'reference'
+  /** The name or id of the stack where the resource is attached */
+  stack: string
+  /** The name of the resource to be referenced */
+  name: string
+}
+/**
  * A union of all possible ownership actions.
  * @category Blueprint Internals
  * @expand
  */
-export type BlueprintOwnershipAction = BlueprintOwnershipAttachAction | BlueprintOwnershipDetachAction
+export type BlueprintOwnershipAction = BlueprintOwnershipAttachAction | BlueprintOwnershipDetachAction | BlueprintOwnershipReferenceAction
 
 /**
  * An ownership action that will cause the referenced project-contained resource to be attached to the current stack.
@@ -45,7 +58,10 @@ export interface BlueprintProjectOwnershipAttachAction extends BlueprintOwnershi
  * @category Blueprint Internals
  * @expand
  */
-export type BlueprintProjectOwnershipAction = BlueprintProjectOwnershipAttachAction | BlueprintOwnershipDetachAction
+export type BlueprintProjectOwnershipAction =
+  | BlueprintProjectOwnershipAttachAction
+  | BlueprintOwnershipDetachAction
+  | BlueprintOwnershipReferenceAction
 
 /**
  * Defines the lifcycle policy for this resource.
@@ -97,4 +113,26 @@ export interface BlueprintResource<Lifecycle extends BlueprintResourceLifecycle 
    * @hidden
    */
   lifecycle?: Lifecycle
+}
+
+/**
+ * The configuration for referencing a resource in another stack.
+ * @category Blueprint Internals
+ */
+export interface BlueprintCrossStackReferenceConfig {
+  /** The name of the resource in the other stack */
+  name: string
+  /** The name or id of the stack being referenced */
+  stack: string
+  /** The local name of the resource, defaults to the name of the other resource */
+  localName?: string
+}
+
+/**
+ * The configuration for referencing a resource in another stack including the type of resource.
+ * @category Blueprint Internals
+ */
+export interface BlueprintCrossStackReferenceResourceConfig extends BlueprintCrossStackReferenceConfig {
+  /** The type of resource being referenced (e.g. `sanity.project`) */
+  type: string
 }

--- a/src/validation/resources.ts
+++ b/src/validation/resources.ts
@@ -39,7 +39,7 @@ export function validateResource(resource: unknown, options?: {projectContained?
       }
 
       if ('ownershipAction' in resource.lifecycle) {
-        const ownershipActionTypes = ['attach', 'detach']
+        const ownershipActionTypes = ['attach', 'detach', 'reference']
         const ownershipAction = resource.lifecycle.ownershipAction
 
         if (typeof ownershipAction !== 'object' || ownershipAction === null) {
@@ -64,6 +64,18 @@ export function validateResource(resource: unknown, options?: {projectContained?
               } else if (typeof ownershipAction.projectId !== 'string') {
                 errors.push({type: 'invalid_type', message: '`ownershipAction.projectId` must be a string'})
               }
+            }
+          } else if (ownershipAction.type === 'reference') {
+            if (!('name' in ownershipAction)) {
+              errors.push({type: 'missing_parameter', message: '`ownershipAction.name` is required for reference'})
+            } else if (typeof ownershipAction.name !== 'string') {
+              errors.push({type: 'invalid_type', message: '`ownershipAction.name` must be a string'})
+            }
+
+            if (!('stack' in ownershipAction)) {
+              errors.push({type: 'missing_parameter', message: '`ownershipAction.stack` is required for reference'})
+            } else if (typeof ownershipAction.stack !== 'string') {
+              errors.push({type: 'invalid_type', message: '`ownershipAction.stack` must be a string'})
             }
           }
         }

--- a/test/integration/resources.typecheck.ts
+++ b/test/integration/resources.typecheck.ts
@@ -16,6 +16,7 @@ import {
   type BlueprintMediaLibraryFunctionResourceEvent,
   type BlueprintModule,
   type BlueprintOutput,
+  type BlueprintProjectResourceLifecycle,
   type BlueprintProjectRoleResource,
   type BlueprintResource,
   type BlueprintRoleConfig,
@@ -64,6 +65,7 @@ const corsOriginResource: BlueprintCorsOriginResource = defineCorsOrigin(corsOri
 const datasetConfig: BlueprintDatasetConfig = {
   name: 'dataset-name',
   aclMode: 'public',
+  description: 'description',
   datasetName: 'production',
   project: 'projectId',
 }
@@ -141,6 +143,34 @@ const roleResource: BlueprintRoleResource = defineRole(roleConfig)
 const projectRoleResource: BlueprintProjectRoleResource = defineProjectRole('projectId', roleConfig)
 
 const blueprintResource: BlueprintResource = {name: 'test-resource', type: 'test'}
+
+const _blueprintProjectLifecycleAttach: BlueprintProjectResourceLifecycle = {
+  deletionPolicy: 'allow',
+  dependsOn: '$.resources.test',
+  ownershipAction: {
+    type: 'attach',
+    projectId: 'project',
+    id: 'id',
+  },
+}
+
+const _blueprintProjectLifecycleDetach: BlueprintProjectResourceLifecycle = {
+  deletionPolicy: 'allow',
+  dependsOn: '$.resources.test',
+  ownershipAction: {
+    type: 'detach',
+  },
+}
+
+const _blueprintProjectLifecycleReference: BlueprintProjectResourceLifecycle = {
+  deletionPolicy: 'allow',
+  dependsOn: '$.resources.test',
+  ownershipAction: {
+    type: 'reference',
+    name: 'name',
+    stack: 'stack',
+  },
+}
 
 const blueprintOutput: BlueprintOutput = {name: 'output', value: 'value'}
 const blueprint: Blueprint = {

--- a/test/unit/definers/project.test.ts
+++ b/test/unit/definers/project.test.ts
@@ -65,3 +65,32 @@ describe('defineProject', () => {
     expect(spy).toHaveBeenCalledOnce()
   })
 })
+
+describe('referenceRobotToken', () => {
+  test('should create a reference to a robot token', () => {
+    const ref = projects.referenceProject({
+      name: 'ref-resource',
+      stack: 'test-stack',
+      localName: 'local-resource',
+    })
+
+    expect(ref.name).toBe('local-resource')
+    expect(ref.type).toBe('sanity.project')
+    expect(ref.lifecycle?.ownershipAction?.type).toBe('reference')
+    expect(ref.lifecycle?.ownershipAction?.type === 'reference' && ref.lifecycle?.ownershipAction?.stack).toBe('test-stack')
+    expect(ref.lifecycle?.ownershipAction?.type === 'reference' && ref.lifecycle?.ownershipAction?.name).toBe('ref-resource')
+  })
+
+  test('should create a reference to a resource using the name as the local name', () => {
+    const ref = projects.referenceProject({
+      name: 'ref-resource',
+      stack: 'test-stack',
+    })
+
+    expect(ref.name).toBe('ref-resource')
+    expect(ref.type).toBe('sanity.project')
+    expect(ref.lifecycle?.ownershipAction?.type).toBe('reference')
+    expect(ref.lifecycle?.ownershipAction?.type === 'reference' && ref.lifecycle?.ownershipAction?.stack).toBe('test-stack')
+    expect(ref.lifecycle?.ownershipAction?.type === 'reference' && ref.lifecycle?.ownershipAction?.name).toBe('ref-resource')
+  })
+})

--- a/test/unit/definers/project.test.ts
+++ b/test/unit/definers/project.test.ts
@@ -66,7 +66,7 @@ describe('defineProject', () => {
   })
 })
 
-describe('referenceRobotToken', () => {
+describe('referenceProject', () => {
   test('should create a reference to a robot token', () => {
     const ref = projects.referenceProject({
       name: 'ref-resource',

--- a/test/unit/definers/resources.test.ts
+++ b/test/unit/definers/resources.test.ts
@@ -29,3 +29,34 @@ describe('defineResource', () => {
     expect(r.lifecycle?.deletionPolicy).toEqual('allow')
   })
 })
+
+describe('referenceResource', () => {
+  test('should create a reference to a resource', () => {
+    const ref = resources.referenceResource({
+      name: 'ref-resource',
+      type: 'test',
+      stack: 'test-stack',
+      localName: 'local-resource',
+    })
+
+    expect(ref.name).toBe('local-resource')
+    expect(ref.type).toBe('test')
+    expect(ref.lifecycle?.ownershipAction?.type).toBe('reference')
+    expect(ref.lifecycle?.ownershipAction?.type === 'reference' && ref.lifecycle?.ownershipAction?.stack).toBe('test-stack')
+    expect(ref.lifecycle?.ownershipAction?.type === 'reference' && ref.lifecycle?.ownershipAction?.name).toBe('ref-resource')
+  })
+
+  test('should create a reference to a resource using the name as the local name', () => {
+    const ref = resources.referenceResource({
+      name: 'ref-resource',
+      type: 'test',
+      stack: 'test-stack',
+    })
+
+    expect(ref.name).toBe('ref-resource')
+    expect(ref.type).toBe('test')
+    expect(ref.lifecycle?.ownershipAction?.type).toBe('reference')
+    expect(ref.lifecycle?.ownershipAction?.type === 'reference' && ref.lifecycle?.ownershipAction?.stack).toBe('test-stack')
+    expect(ref.lifecycle?.ownershipAction?.type === 'reference' && ref.lifecycle?.ownershipAction?.name).toBe('ref-resource')
+  })
+})

--- a/test/unit/definers/robotTokens.test.ts
+++ b/test/unit/definers/robotTokens.test.ts
@@ -94,3 +94,32 @@ describe('defineRobotToken', () => {
     expect(spy).toHaveBeenCalledOnce()
   })
 })
+
+describe('referenceRobotToken', () => {
+  test('should create a reference to a robot token', () => {
+    const ref = robotTokens.referenceRobotToken({
+      name: 'ref-resource',
+      stack: 'test-stack',
+      localName: 'local-resource',
+    })
+
+    expect(ref.name).toBe('local-resource')
+    expect(ref.type).toBe('sanity.access.robot')
+    expect(ref.lifecycle?.ownershipAction?.type).toBe('reference')
+    expect(ref.lifecycle?.ownershipAction?.type === 'reference' && ref.lifecycle?.ownershipAction?.stack).toBe('test-stack')
+    expect(ref.lifecycle?.ownershipAction?.type === 'reference' && ref.lifecycle?.ownershipAction?.name).toBe('ref-resource')
+  })
+
+  test('should create a reference to a resource using the name as the local name', () => {
+    const ref = robotTokens.referenceRobotToken({
+      name: 'ref-resource',
+      stack: 'test-stack',
+    })
+
+    expect(ref.name).toBe('ref-resource')
+    expect(ref.type).toBe('sanity.access.robot')
+    expect(ref.lifecycle?.ownershipAction?.type).toBe('reference')
+    expect(ref.lifecycle?.ownershipAction?.type === 'reference' && ref.lifecycle?.ownershipAction?.stack).toBe('test-stack')
+    expect(ref.lifecycle?.ownershipAction?.type === 'reference' && ref.lifecycle?.ownershipAction?.name).toBe('ref-resource')
+  })
+})

--- a/test/unit/definers/roles.test.ts
+++ b/test/unit/definers/roles.test.ts
@@ -152,3 +152,32 @@ describe('defineProjectRole', () => {
     expect(roleResource.lifecycle?.ownershipAction?.projectId).toStrictEqual('test-project')
   })
 })
+
+describe('referenceRole', () => {
+  test('should create a reference to a role', () => {
+    const ref = roles.referenceRole({
+      name: 'ref-resource',
+      stack: 'test-stack',
+      localName: 'local-resource',
+    })
+
+    expect(ref.name).toBe('local-resource')
+    expect(ref.type).toBe('sanity.access.role')
+    expect(ref.lifecycle?.ownershipAction?.type).toBe('reference')
+    expect(ref.lifecycle?.ownershipAction?.type === 'reference' && ref.lifecycle?.ownershipAction?.stack).toBe('test-stack')
+    expect(ref.lifecycle?.ownershipAction?.type === 'reference' && ref.lifecycle?.ownershipAction?.name).toBe('ref-resource')
+  })
+
+  test('should create a reference to a resource using the name as the local name', () => {
+    const ref = roles.referenceRole({
+      name: 'ref-resource',
+      stack: 'test-stack',
+    })
+
+    expect(ref.name).toBe('ref-resource')
+    expect(ref.type).toBe('sanity.access.role')
+    expect(ref.lifecycle?.ownershipAction?.type).toBe('reference')
+    expect(ref.lifecycle?.ownershipAction?.type === 'reference' && ref.lifecycle?.ownershipAction?.stack).toBe('test-stack')
+    expect(ref.lifecycle?.ownershipAction?.type === 'reference' && ref.lifecycle?.ownershipAction?.name).toBe('ref-resource')
+  })
+})

--- a/test/unit/validation/resources.test.ts
+++ b/test/unit/validation/resources.test.ts
@@ -70,7 +70,7 @@ describe('validateResource', () => {
 
   test('should return an error if lifecycle.ownershipAction.type is not valid', () => {
     const errors = validateResource({name: 'test', type: 'test', lifecycle: {ownershipAction: {type: 'invalid'}}})
-    expect(errors).toContainEqual({type: 'invalid_value', message: '`ownershipAction.type` must be one of attach, detach'})
+    expect(errors).toContainEqual({type: 'invalid_value', message: '`ownershipAction.type` must be one of attach, detach, reference'})
   })
 
   test('should return an error if lifecycle.ownershipAction has no id', () => {
@@ -99,6 +99,34 @@ describe('validateResource', () => {
     expect(errors).toContainEqual({type: 'invalid_type', message: '`ownershipAction.projectId` must be a string'})
   })
 
+  test('should return an error if lifecycle.ownershipAction has no name', () => {
+    const errors = validateResource({name: 'test', type: 'test', lifecycle: {ownershipAction: {type: 'reference'}}})
+    expect(errors).toContainEqual({type: 'missing_parameter', message: '`ownershipAction.name` is required for reference'})
+  })
+
+  test('should return an error if lifecycle.ownershipAction.name is not a string', () => {
+    const errors = validateResource({
+      name: 'test',
+      type: 'test',
+      lifecycle: {ownershipAction: {type: 'reference', name: 1, stack: 'test-stack'}},
+    })
+    expect(errors).toContainEqual({type: 'invalid_type', message: '`ownershipAction.name` must be a string'})
+  })
+
+  test('should return an error if lifecycle.ownershipAction has no stack', () => {
+    const errors = validateResource({name: 'test', type: 'test', lifecycle: {ownershipAction: {type: 'reference', name: 'name'}}})
+    expect(errors).toContainEqual({type: 'missing_parameter', message: '`ownershipAction.stack` is required for reference'})
+  })
+
+  test('should return an error if lifecycle.ownershipAction.stack is not a string', () => {
+    const errors = validateResource({
+      name: 'test',
+      type: 'test',
+      lifecycle: {ownershipAction: {type: 'reference', name: 'name', stack: 1}},
+    })
+    expect(errors).toContainEqual({type: 'invalid_type', message: '`ownershipAction.stack` must be a string'})
+  })
+
   test('should return an error if lifecycle.dependsOn is not a string', () => {
     const errors = validateResource({name: 'test', type: 'test', lifecycle: {dependsOn: 123}})
     expect(errors).toContainEqual({type: 'invalid_type', message: '`lifecycle.dependsOn` must be a string'})
@@ -117,7 +145,7 @@ describe('validateResource', () => {
     expect(errors).toHaveLength(0)
   })
 
-  test('should return no errors for a valid resource', () => {
+  test('should return no errors for a valid resource (attach)', () => {
     const errors = validateResource({
       name: 'test',
       type: 'test',
@@ -126,6 +154,36 @@ describe('validateResource', () => {
         ownershipAction: {
           type: 'attach',
           id: 'test-id',
+        },
+      },
+    })
+    expect(errors).toHaveLength(0)
+  })
+
+  test('should return no errors for a valid resource (detach)', () => {
+    const errors = validateResource({
+      name: 'test',
+      type: 'test',
+      lifecycle: {
+        deletionPolicy: 'allow',
+        ownershipAction: {
+          type: 'detach',
+        },
+      },
+    })
+    expect(errors).toHaveLength(0)
+  })
+
+  test('should return no errors for a valid resource (reference)', () => {
+    const errors = validateResource({
+      name: 'test',
+      type: 'test',
+      lifecycle: {
+        deletionPolicy: 'allow',
+        ownershipAction: {
+          type: 'reference',
+          name: 'test-name',
+          stack: 'test-stack',
         },
       },
     })

--- a/typedoc.json
+++ b/typedoc.json
@@ -11,6 +11,7 @@
   "excludeExternals": true,
   "categoryOrder": [
     "Definers", // src/definers/
+    "Referencers", // src/definers/
     "Resource Types", // src/types/
     "Functions Types", // function resource types
     "Validation", // src/validation/


### PR DESCRIPTION
### Description

In order to create a reference we need to avoid the normal validation done when defining a resource. These new functions will let users reference roles, robot tokens and projects. We can add more later if needed but other types will be much less likely to be referenced.

### Testing

Added unit tests for all new functions
