### PR TITLE
feat: add support for sync-tag-invalidate functions

### DIFF
--- a/src/definers/functions.ts
+++ b/src/definers/functions.ts
@@ -13,10 +13,13 @@ import {
   type BlueprintScheduledFunctionExpressionResourceEvent,
   type BlueprintScheduledFunctionResource,
   type BlueprintScheduledFunctionResourceEvent,
+  type BlueprintSyncTagInvalidateFunctionConfig,
+  type BlueprintSyncTagInvalidateFunctionResource,
   validateDocumentFunction,
   validateFunction,
   validateMediaLibraryAssetFunction,
   validateScheduledFunction,
+  validateSyncTagInvalidateFunction,
 } from '../index.js'
 import {parseScheduledExpression} from '../utils/schedule-parser.js'
 import {runValidation} from '../utils/validation.js'
@@ -268,6 +271,53 @@ export function defineScheduledFunction(functionConfig: BlueprintScheduledFuncti
  */
 export function defineScheduleFunction(functionConfig: BlueprintScheduledFunctionConfig): BlueprintScheduledFunctionResource {
   return defineScheduledFunction(functionConfig)
+}
+
+/**
+ * Defines a function that is triggered on a sync tag invalidate event.
+ *
+ * @remarks
+ * Using implicit event scoping to all datasets in the function project:
+ * ```ts
+ * defineSyncTagInvalidateFunction({
+ *   name: 'bustin-caches',
+ * })
+ * ```
+ *
+ * Using explicit event scoping to a particular dataset in the function project:
+ * ```ts
+ * defineSyncTagInvalidateFunction({
+ *   name: 'bustin-caches',
+ *   event: {
+ *     resource: {
+ *       type: 'dataset',
+ *       id: 'myProj.myDataset',
+ *     },
+ *   },
+ * })
+ * ```
+ * @public
+ * @alpha Deploying Sync Tag Invalidate Functions via Blueprints is experimental. This feature is not available publicly yet.
+ * @hidden
+ * @category Definers
+ * @expandType BlueprintSyncTagInvalidateFunctionConfig
+ * @param functionConfig The configuration for the sync tag invalidate function
+ * @returns The validated sync tag invalidate function resource
+ */
+export function defineSyncTagInvalidateFunction(
+  functionConfig: BlueprintSyncTagInvalidateFunctionConfig,
+): BlueprintSyncTagInvalidateFunctionResource {
+  const {event} = functionConfig
+
+  const functionResource: BlueprintSyncTagInvalidateFunctionResource = {
+    ...defineFunction(functionConfig, {skipValidation: true}),
+    type: 'sanity.function.sync-tag-invalidate',
+    ...(event?.resource ? {event} : {}),
+  }
+
+  runValidation(() => validateSyncTagInvalidateFunction(functionResource))
+
+  return functionResource
 }
 
 /**

--- a/src/types/functions/event.ts
+++ b/src/types/functions/event.ts
@@ -39,6 +39,15 @@ export interface BlueprintMediaLibraryFunctionResourceEvent extends BlueprintFun
 }
 
 /**
+ * Event configuration for sync tag invalidate functions
+ * @category Functions Types
+ */
+export interface BlueprintSyncTagInvalidateFunctionResourceEvent {
+  /** Optional dataset resource scoping for the function */
+  resource?: BlueprintFunctionResourceEventResourceDataset
+}
+
+/**
  * Explicit resource event for scheduled functions to specific minutes, hours, days of month, months, and days of week
  * @example { minute: '0', hour: '9', dayOfMonth: '1', month: '1', dayOfWeek: '1' }
  * @category Functions Types
@@ -76,6 +85,7 @@ export type BlueprintFunctionResourceEvent =
   | BlueprintDocumentFunctionResourceEvent
   | BlueprintMediaLibraryFunctionResourceEvent
   | BlueprintScheduledFunctionResourceEvent
+  | BlueprintSyncTagInvalidateFunctionResourceEvent
 
 /**
  * Dataset resource for scoping document functions to specific datasets

--- a/src/types/functions/index.ts
+++ b/src/types/functions/index.ts
@@ -3,6 +3,7 @@ import type {
   BlueprintDocumentFunctionResourceEvent,
   BlueprintMediaLibraryFunctionResourceEvent,
   BlueprintScheduledFunctionResourceEvent,
+  BlueprintSyncTagInvalidateFunctionResourceEvent,
 } from './event.js'
 
 export * from './event.js'
@@ -81,6 +82,15 @@ export interface BlueprintScheduledFunctionResource extends BlueprintBaseFunctio
   timezone?: string
 }
 
+/**
+ * A function resource triggered by sync tag invalidate events
+ * @category Functions Types
+ */
+export interface BlueprintSyncTagInvalidateFunctionResource extends BlueprintBaseFunctionResource {
+  type: 'sanity.function.sync-tag-invalidate'
+  event?: BlueprintSyncTagInvalidateFunctionResourceEvent
+}
+
 // --- Function Config Types ---
 
 /**
@@ -139,6 +149,22 @@ export type BlueprintMediaLibraryAssetFunctionConfig = Omit<BlueprintMediaLibrar
  * @interface
  */
 export type BlueprintScheduledFunctionConfig = Omit<BlueprintScheduledFunctionResource, 'type' | 'src'> & {
+  /**
+   * Path to the function source code
+   * @defaultValue `functions/${name}`
+   */
+  src?: string
+}
+
+/**
+ * Configuration for defining a sync tag invalidate function.
+ * @public
+ * @alpha Deploying Sync Tag Invalidate Functions via Blueprints is experimental. This feature is not available publicly yet.
+ * @hidden
+ * @category Functions Types
+ * @interface
+ */
+export type BlueprintSyncTagInvalidateFunctionConfig = Omit<BlueprintSyncTagInvalidateFunctionResource, 'type' | 'src'> & {
   /**
    * Path to the function source code
    * @defaultValue `functions/${name}`

--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -158,8 +158,8 @@ function validateDocumentFunctionEvent(event: unknown): BlueprintError[] {
 
 function validateFunctionEventResourceDataset(event: unknown): BlueprintError[] {
   const errors: BlueprintError[] = []
-  if (!event || typeof event !== 'object') return [{type: 'invalid_value', message: '`event must be an object'}]
-  if (!('resource' in event)) return [{type: 'invalid_value', message: '`event.resource must exist'}]
+  if (!event || typeof event !== 'object') return [{type: 'invalid_value', message: '`event` must be an object'}]
+  if (!('resource' in event)) return [{type: 'invalid_value', message: '`event.resource` must exist'}]
   const resource = event.resource
   if (!resource || typeof resource !== 'object') return [{type: 'invalid_value', message: '`event.resource` must be an object'}]
   if (!('type' in resource) || !resource.type || resource.type !== 'dataset')

--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -151,14 +151,20 @@ function validateDocumentFunctionEvent(event: unknown): BlueprintError[] {
   }
   if (!Array.isArray(fullEvent.on)) errors.push({type: 'invalid_type', message: '`event.on` must be an array'})
   if (fullEvent.resource) {
-    if (!fullEvent.resource.type || fullEvent.resource.type !== 'dataset')
-      errors.push({type: 'invalid_value', message: '`event.resource.type` must be "dataset"'})
-    if (!fullEvent.resource.id || fullEvent.resource.id.split('.').length !== 2)
-      errors.push({type: 'invalid_format', message: '`event.resource.id` must be in the format <projectId>.<datasetName>'})
+    errors.push(...validateFunctionEventResourceDataset(fullEvent.resource))
   }
   return errors
 }
 
+function validateFunctionEventResourceDataset(resource: unknown): BlueprintError[] {
+  const errors: BlueprintError[] = []
+  if (!resource || typeof resource !== 'object') return [{type: 'invalid_value', message: '`event.resource must be an object'}]
+  if (!('type' in resource) || !resource.type || resource.type !== 'dataset')
+    errors.push({type: 'invalid_value', message: '`event.resource.type` must be "dataset"'})
+  if (!('id' in resource) || !resource.id || typeof resource.id !== 'string' || resource.id.split('.').length !== 2)
+    errors.push({type: 'invalid_format', message: '`event.resource.id` must be in the format <projectId>.<datasetName>'})
+  return errors
+}
 /**
  * Validates a media library function event configuration.
  * Checks event trigger types and ensures required media library resource is present.
@@ -316,6 +322,33 @@ function validateScheduledFunctionTimezone(timezone: unknown): BlueprintError[] 
       message: '`timezone` must be a valid IANA timezone',
     })
   }
+
+  return errors
+}
+
+/**
+ * Validates a sync tag invalidate function resource configuration.
+ * @param functionResource The function resource to validate
+ * @alpha
+ * @hidden
+ * @category Functions Types
+ * @returns Array of validation errors, empty if valid
+ */
+export function validateSyncTagInvalidateFunction(functionResource: unknown): BlueprintError[] {
+  if (!functionResource) return [{type: 'invalid_value', message: 'Function config must be provided'}]
+  if (typeof functionResource !== 'object') return [{type: 'invalid_type', message: 'Function config must be an object'}]
+
+  const errors: BlueprintError[] = []
+
+  if ('type' in functionResource && functionResource.type !== 'sanity.function.sync-tag-invalidate') {
+    errors.push({type: 'invalid_value', message: '`type` must be `sanity.function.sync-tag-invalidate`'})
+  }
+
+  if ('event' in functionResource) {
+    errors.push(...validateFunctionEventResourceDataset(functionResource.event))
+  }
+
+  errors.push(...validateFunction(functionResource))
 
   return errors
 }

--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -151,14 +151,17 @@ function validateDocumentFunctionEvent(event: unknown): BlueprintError[] {
   }
   if (!Array.isArray(fullEvent.on)) errors.push({type: 'invalid_type', message: '`event.on` must be an array'})
   if (fullEvent.resource) {
-    errors.push(...validateFunctionEventResourceDataset(fullEvent.resource))
+    errors.push(...validateFunctionEventResourceDataset(fullEvent))
   }
   return errors
 }
 
-function validateFunctionEventResourceDataset(resource: unknown): BlueprintError[] {
+function validateFunctionEventResourceDataset(event: unknown): BlueprintError[] {
   const errors: BlueprintError[] = []
-  if (!resource || typeof resource !== 'object') return [{type: 'invalid_value', message: '`event.resource must be an object'}]
+  if (!event || typeof event !== 'object') return [{type: 'invalid_value', message: '`event must be an object'}]
+  if (!('resource' in event)) return [{type: 'invalid_value', message: '`event.resource must exist'}]
+  const resource = event.resource
+  if (!resource || typeof resource !== 'object') return [{type: 'invalid_value', message: '`event.resource` must be an object'}]
   if (!('type' in resource) || !resource.type || resource.type !== 'dataset')
     errors.push({type: 'invalid_value', message: '`event.resource.type` must be "dataset"'})
   if (!('id' in resource) || !resource.id || typeof resource.id !== 'string' || resource.id.split('.').length !== 2)

--- a/test/integration/imports.test.ts
+++ b/test/integration/imports.test.ts
@@ -10,6 +10,7 @@ import {
   defineResource,
   defineRole,
   defineScheduledFunction,
+  defineSyncTagInvalidateFunction,
   validateBlueprint,
   validateCorsOrigin,
   validateDataset,
@@ -19,6 +20,7 @@ import {
   validateMediaLibraryAssetFunction,
   validateResource,
   validateRole,
+  validateSyncTagInvalidateFunction,
 } from '@sanity/blueprints'
 import {describe, expect, it} from 'vitest'
 
@@ -41,6 +43,10 @@ describe('package imports', () => {
 
   it('should import defineScheduledFunction', () => {
     expect(defineScheduledFunction).toBeInstanceOf(Function)
+  })
+
+  it('should import defineSyncTagInvalidateFunction', () => {
+    expect(defineSyncTagInvalidateFunction).toBeInstanceOf(Function)
   })
 
   it('should import defineDocumentWebhook', () => {
@@ -81,6 +87,10 @@ describe('package imports', () => {
 
   it('should import validateDocumentFunction', () => {
     expect(validateDocumentFunction).toBeInstanceOf(Function)
+  })
+
+  it('should import validateSyncTagInvalidateFunction', () => {
+    expect(validateSyncTagInvalidateFunction).toBeInstanceOf(Function)
   })
 
   it('should import validateDocumentWebhook', () => {

--- a/test/integration/resources.typecheck.ts
+++ b/test/integration/resources.typecheck.ts
@@ -23,6 +23,8 @@ import {
   type BlueprintRoleResource,
   type BlueprintScheduledFunctionResource,
   type BlueprintScheduledFunctionResourceEvent,
+  type BlueprintSyncTagInvalidateFunctionResource,
+  type BlueprintSyncTagInvalidateFunctionResourceEvent,
   defineCorsOrigin,
   defineDataset,
   defineDocumentFunction,
@@ -31,6 +33,7 @@ import {
   defineProjectRole,
   defineRole,
   defineScheduledFunction,
+  defineSyncTagInvalidateFunction,
   type RolePermission,
   validateBlueprint,
   validateCorsOrigin,
@@ -42,6 +45,7 @@ import {
   validateResource,
   validateRole,
   validateScheduledFunction,
+  validateSyncTagInvalidateFunction,
   // type BlueprintsApiConfig,
   type WebhookTrigger,
 } from '@sanity/blueprints'
@@ -95,6 +99,14 @@ const scheduledFunctionResource: BlueprintScheduledFunctionResource = defineSche
   name: 'sup',
   event: scheduledFunctionResourceEvent,
   timezone: 'America/New_York',
+})
+const _bareSyncTagInvalidateFunctionResourceEvent: BlueprintSyncTagInvalidateFunctionResourceEvent = {}
+const fullyQualifiedSyncTagInvalidateFunctionResourceEvent: BlueprintSyncTagInvalidateFunctionResourceEvent = {
+  resource: {type: 'dataset', id: 'proj.dataset'},
+}
+const syncTagInvalidateFunction: BlueprintSyncTagInvalidateFunctionResource = defineSyncTagInvalidateFunction({
+  name: 'yoyoyo',
+  event: fullyQualifiedSyncTagInvalidateFunctionResourceEvent,
 })
 
 const documentWebhookConfig: BlueprintDocumentWebhookConfig = {
@@ -205,3 +217,4 @@ validateMediaLibraryAssetFunction(mediaLibraryAssetFunctionResource)
 validateResource(blueprintResource)
 validateRole(roleResource)
 validateScheduledFunction(scheduledFunctionResource)
+validateSyncTagInvalidateFunction(syncTagInvalidateFunction)

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -241,7 +241,7 @@ describe('validateMediaLibraryAssetFunction', () => {
 
 describe('validateScheduledFunction', () => {
   describe('happy paths', () => {
-    test('should accept a valid media library function', () => {
+    test('should accept a valid scheduled function', () => {
       const errors = functions.validateScheduledFunction({
         name: 'test',
         type: 'sanity.function.cron',
@@ -249,7 +249,7 @@ describe('validateScheduledFunction', () => {
       })
       expect(errors).toHaveLength(0)
     })
-    test('should accept a valid media library function with optional timezone', () => {
+    test('should accept a valid scheduled function with optional timezone', () => {
       const errors = functions.validateScheduledFunction({
         name: 'test',
         type: 'sanity.function.cron',
@@ -369,6 +369,64 @@ describe('validateScheduledFunction', () => {
         event: {minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: 1},
       })
       expect(errors).toContainEqual({type: 'invalid_type', message: '`dayOfWeek` must be a string'})
+    })
+  })
+})
+
+describe('validateSyncTagInvalidateFunction', () => {
+  describe('happy paths', () => {
+    test('should accept a valid sync tag invalidate function without any optional properties', () => {
+      const errors = functions.validateSyncTagInvalidateFunction({
+        name: 'test',
+        type: 'sanity.function.sync-tag-invalidate',
+      })
+      expect(errors).toStrictEqual([])
+    })
+    test('should accept a valid sync tag invalidate function with optional dataset specifier', () => {
+      const errors = functions.validateSyncTagInvalidateFunction({
+        name: 'test',
+        type: 'sanity.function.sync-tag-invalidate',
+        event: {resource: {type: 'dataset', id: 'myProj.myDataset'}},
+      })
+      expect(errors).toStrictEqual([])
+    })
+  })
+  describe('sad paths', () => {
+    test('should return an error if the type is not `sanity.function.sync-tag-invalidate`', () => {
+      const errors = functions.validateSyncTagInvalidateFunction({type: 'invalid'})
+      expect(errors).toContainEqual({
+        type: 'invalid_value',
+        message: '`type` must be `sanity.function.sync-tag-invalidate`',
+      })
+    })
+    test('should return an error if event.resource is invalid', () => {
+      let errors = functions.validateSyncTagInvalidateFunction({
+        name: 'test',
+        type: 'sanity.function.sync-tag-invalidate',
+        event: {resource: true},
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_value',
+        message: '`event.resource` must be an object',
+      })
+      errors = functions.validateSyncTagInvalidateFunction({
+        name: 'test',
+        type: 'sanity.function.sync-tag-invalidate',
+        event: {resource: {id: 'proj.dataset'}},
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_value',
+        message: '`event.resource.type` must be "dataset"',
+      })
+      errors = functions.validateSyncTagInvalidateFunction({
+        name: 'test',
+        type: 'sanity.function.sync-tag-invalidate',
+        event: {resource: {type: 'dataset'}},
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_format',
+        message: '`event.resource.id` must be in the format <projectId>.<datasetName>',
+      })
     })
   })
 })


### PR DESCRIPTION
### Description

Adds support for sync-tag-invalidate functions.

Note that these will not work yet, but want to get this released so that I have the types for this function I can use to implement the provider.

Resolves [RUN-1201](https://linear.app/sanity/issue/RUN-1201/sanityblueprints-resource-shape-and-support-for-cache-function).