### PR TITLE
fix: Switch to displayName for robots and roles

### DIFF
--- a/src/definers/robotTokens.ts
+++ b/src/definers/robotTokens.ts
@@ -14,14 +14,14 @@ import {runValidation} from '../utils/validation.js'
  * ```ts
  * defineRole({
  *   name: 'ci-deploy-role',
- *   title: 'CI Deploy Role',
+ *   displayName: 'CI Deploy Role',
  *   appliesToRobots: true,
  *   permissions: [{name: 'sanity-project-cors', action: 'create'}],
  * })
  *
  * defineRobotToken({
  *   name: 'ci-robot',
- *   label: 'CI Deploy Robot',
+ *   displayname: 'CI Deploy Robot',
  *   memberships: [{
  *     roleNames: ['$.resources.ci-deploy-role'],
  *   }],
@@ -49,11 +49,13 @@ import {runValidation} from '../utils/validation.js'
  * @returns The robot token resource
  */
 export function defineRobotToken(parameters: BlueprintRobotTokenConfig): BlueprintRobotTokenResource {
-  const label = parameters.label || parameters.name
+  const label = ('label' in parameters && parameters.label) || parameters.name
+  const displayName = ('displayName' in parameters && parameters.displayName) || parameters.name
 
   const robotResource: BlueprintRobotTokenResource = {
     ...parameters,
     label,
+    displayName,
     type: 'sanity.access.robot',
   }
 

--- a/src/definers/roles.ts
+++ b/src/definers/roles.ts
@@ -16,7 +16,7 @@ import {runValidation} from '../utils/validation.js'
  * ```ts
  * defineRole({
  *   name: 'ci-deploy-role',
- *   title: 'CI Deploy Role',
+ *   displayname: 'CI Deploy Role',
  *   description: 'Permissions for CI/CD pipelines to manage CORS and datasets',
  *   appliesToRobots: true,
  *   appliesToUsers: false,
@@ -39,7 +39,7 @@ import {runValidation} from '../utils/validation.js'
  * ```ts
  * defineRole({
  *   name: 'custom-robot-role',
- *   title: 'Custom Robot Role',
+ *   displayname: 'Custom Robot Role',
  *   appliesToRobots: true,
  *   permissions: [{
  *     name: 'sanity-project-cors',
@@ -58,7 +58,8 @@ export function defineRole(parameters: BlueprintRoleConfig, options?: {skipValid
   const roleResource: BlueprintRoleResource = {
     name: parameters.name,
     type: 'sanity.access.role',
-    title: parameters.title,
+    title: ('title' in parameters && parameters.title) || undefined,
+    displayName: ('displayName' in parameters && parameters.displayName) || undefined,
     description: parameters.description,
     appliesToUsers: parameters.appliesToUsers,
     appliesToRobots: parameters.appliesToRobots,
@@ -80,7 +81,7 @@ export function defineRole(parameters: BlueprintRoleConfig, options?: {skipValid
  * ```ts
  * const role = defineProjectRole(projectId, {
  *   name: 'ci-deploy-role',
- *   title: 'CI Deploy Role',
+ *   displayname: 'CI Deploy Role',
  *   appliesToRobots: true,
  *   permissions: [{
  *     name: 'sanity-project-cors',
@@ -107,7 +108,7 @@ export function defineRole(parameters: BlueprintRoleConfig, options?: {skipValid
  * ```ts
  * defineProjectRole(projectId, {
  *   name: 'viewer-role',
- *   title: 'Viewer',
+ *   displayname: 'Viewer',
  *   appliesToUsers: true,
  *   permissions: [{
  *     name: 'sanity-project-cors',

--- a/src/types/robotTokens.ts
+++ b/src/types/robotTokens.ts
@@ -20,14 +20,23 @@ export interface RobotTokenMembership {
 
 /**
  * A robot token that provides automated access.
+ *
+ * This feature is subject to breaking changes.
+ *
  * @see https://www.sanity.io/docs/content-lake/http-auth#k4c21d7b829fe
- * @beta This feature is subject to breaking changes.
+ * @beta
  * @category Resource Types
  */
 export interface BlueprintRobotTokenResource extends BlueprintResource<BlueprintProjectResourceLifecycle> {
   type: 'sanity.access.robot'
+  /**
+   * A descriptive label for the robot token and its use case
+   * @hidden
+   */
+  label?: string
   /** A descriptive label for the robot token and its use case */
-  label: string
+  displayName?: string
+  /** A list of memberships that the robot token has */
   memberships: RobotTokenMembership[]
 
   resourceType?: RobotTokenResourceType
@@ -36,15 +45,30 @@ export interface BlueprintRobotTokenResource extends BlueprintResource<Blueprint
 
 /**
  * Configuration for a robot token that provides automated access.
+ *
+ * This feature is subject to breaking changes.
  * @see https://www.sanity.io/docs/content-lake/http-auth#k4c21d7b829fe
- * @beta This feature is subject to breaking changes.
+ * @beta
  * @category Resource Types
  * @interface
  */
-export type BlueprintRobotTokenConfig = Omit<BlueprintRobotTokenResource, 'type' | 'label' | 'token'> & {
-  /**
-   * A descriptive label for the robot token and its use case
-   * @defaultValue The `name` of the resource
-   */
-  label?: string
-}
+export type BlueprintRobotTokenConfig = Omit<BlueprintRobotTokenResource, 'type' | 'label' | 'displayName' | 'token'> &
+  (
+    | {
+        /**
+         * A descriptive label for the robot token and its use case
+         * @defaultValue The `name` of the resource
+         * @hidden
+         */
+        label: string
+        //displayName: never
+      }
+    | {
+        /**
+         * A descriptive label for the robot token and its use case
+         * @defaultValue The `name` of the resource
+         */
+        displayName: string
+        //label: never
+      }
+  )

--- a/src/types/roles.ts
+++ b/src/types/roles.ts
@@ -19,30 +19,65 @@ export interface RolePermission {
  * Configuration for a custom role.
  * @beta This feature is subject to breaking changes.
  * @category Resource Types
+ * @interface
  */
-export interface BlueprintRoleConfig extends Omit<BlueprintResource<BlueprintProjectResourceLifecycle>, 'type'> {
-  title: string
-  description?: string
-  appliesToUsers: boolean
-  appliesToRobots: boolean
-  permissions: RolePermission[]
+export type BlueprintRoleConfig = Omit<BlueprintResource<BlueprintProjectResourceLifecycle>, 'type'> &
+  (
+    | {
+        /**
+         * A descriptive title for the role
+         * @defaultValue The `name` of the resource
+         * @hidden
+         */
+        title: string
+      }
+    | {
+        /**
+         * A descriptive title for the role
+         * @defaultValue The `name` of the resource
+         */
+        displayName: string
+      }
+  ) & {
+    description?: string
+    appliesToUsers: boolean
+    appliesToRobots: boolean
+    permissions: RolePermission[]
+  }
+
+type RoleDisplay = {
+  /**
+   * A descriptive title for the role
+   * @defaultValue The `name` of the resource
+   * @hidden
+   */
+  title?: string
+  /**
+   * A descriptive title for the role
+   * @defaultValue The `name` of the resource
+   */
+  displayName?: string
 }
 
 /**
  * A custom role resource
  * @beta This feature is subject to breaking changes.
  * @category Resource Types
+ * @interface
  */
-export interface BlueprintRoleResource extends BlueprintRoleConfig, BlueprintResource<BlueprintProjectResourceLifecycle> {
-  type: 'sanity.access.role'
-}
+export type BlueprintRoleResource = Omit<BlueprintRoleConfig, 'title' | 'displayName'> &
+  RoleDisplay &
+  BlueprintResource<BlueprintProjectResourceLifecycle> & {
+    type: 'sanity.access.role'
+  }
 
 /**
  * A custom role resource that is tied to a specific project
  * @beta This feature is subject to breaking changes.
  * @category Resource Types
+ * @interface
  */
-export interface BlueprintProjectRoleResource extends BlueprintRoleResource {
+export type BlueprintProjectRoleResource = BlueprintRoleResource & {
   resourceType: 'project'
   resourceId: string
 }

--- a/test/integration/resources.typecheck.ts
+++ b/test/integration/resources.typecheck.ts
@@ -19,6 +19,7 @@ import {
   type BlueprintProjectResourceLifecycle,
   type BlueprintProjectRoleResource,
   type BlueprintResource,
+  type BlueprintRobotTokenConfig,
   type BlueprintRoleConfig,
   type BlueprintRoleResource,
   type BlueprintScheduledFunctionResource,
@@ -31,9 +32,11 @@ import {
   defineDocumentWebhook,
   defineMediaLibraryAssetFunction,
   defineProjectRole,
+  defineRobotToken,
   defineRole,
   defineScheduledFunction,
   defineSyncTagInvalidateFunction,
+  type RobotMembership,
   type RolePermission,
   validateBlueprint,
   validateCorsOrigin,
@@ -141,6 +144,18 @@ const mediaLibraryAssetFunctionResource: BlueprintMediaLibraryAssetFunctionResou
   name: 'required',
   event: mediaLibraryAssetFunctionEvent,
 })
+
+const robotTokenMembership: RobotMembership = {
+  resourceType: 'organization',
+  resourceId: 'test-org',
+  roleNames: ['my-role'],
+}
+const robotTokenConfig: BlueprintRobotTokenConfig = {
+  name: 'my-robot',
+  displayName: 'HAL',
+  memberships: [robotTokenMembership],
+}
+const _robotTokenResource = defineRobotToken(robotTokenConfig)
 
 const rolePermission: RolePermission = {action: 'read', name: 'sanity-test-read'}
 const roleConfig: BlueprintRoleConfig = {


### PR DESCRIPTION
### Description

Use displayName instead of label or title in robots and roles.

### What to review

Make sure I got the really awkward types correct

### Testing

Updated tests as needed
