### PR TITLE
fix: Prevent expression from being allowed in scheduled function event

### DIFF
--- a/src/definers/functions.ts
+++ b/src/definers/functions.ts
@@ -9,6 +9,7 @@ import {
   type BlueprintMediaLibraryAssetFunctionResource,
   type BlueprintMediaLibraryFunctionResourceEvent,
   type BlueprintScheduledFunctionConfig,
+  type BlueprintScheduledFunctionConfigEvent,
   type BlueprintScheduledFunctionExplicitResourceEvent,
   type BlueprintScheduledFunctionExpressionResourceEvent,
   type BlueprintScheduledFunctionResource,
@@ -247,20 +248,20 @@ export function defineScheduledFunction(functionConfig: BlueprintScheduledFuncti
   const {event, timezone} = functionConfig
 
   const functionResource: BlueprintScheduledFunctionResource = {
-    ...defineFunction(functionConfig, {skipValidation: true}),
+    ...defineFunction(functionConfig, {skipValidation: true, scopeType: 'organization'}),
     type: 'sanity.function.cron',
     event: buildScheduledFunctionEvent(event),
   }
 
   if (timezone) functionResource.timezone = timezone
 
-  runValidation(() => validateScheduledFunction(functionResource))
-
   // Always normalize to explicit fields (minute, hour, dayOfWeek, month, dayOfMonth)
-  if ('expression' in functionResource.event && functionResource.event.expression) {
+  if ('expression' in functionResource.event && typeof functionResource.event.expression === 'string') {
     const cron = parseScheduledExpression(functionResource.event.expression)
     functionResource.event = cronStringToExplicitEvent(cron)
   }
+
+  runValidation(() => validateScheduledFunction(functionResource))
 
   return functionResource
 }
@@ -332,7 +333,7 @@ export function defineSyncTagInvalidateFunction(
  */
 export function defineFunction(
   functionConfig: BlueprintBaseFunctionConfig,
-  options?: {skipValidation?: boolean},
+  options?: {skipValidation?: boolean; scopeType?: 'organization'},
 ): BlueprintBaseFunctionResource {
   const {name, displayName, src, timeout, memory, env, robotToken, project, runtime, lifecycle} = functionConfig
 
@@ -345,9 +346,10 @@ export function defineFunction(
     memory,
     env,
     robotToken,
-    project,
     runtime,
   }
+
+  if (options?.scopeType !== 'organization' && project) functionResource.project = project
 
   if (lifecycle) functionResource.lifecycle = lifecycle
 
@@ -397,7 +399,7 @@ function buildMediaLibraryFunctionEvent(event: BlueprintMediaLibraryFunctionReso
  * @param event Scheduled function event configuration
  * @returns Cleaned scheduled function event configuration
  */
-function buildScheduledFunctionEvent(event: BlueprintScheduledFunctionResourceEvent): BlueprintScheduledFunctionResourceEvent {
+function buildScheduledFunctionEvent(event: BlueprintScheduledFunctionConfigEvent): BlueprintScheduledFunctionResourceEvent {
   return Object.fromEntries(
     Object.entries(event).filter(([key]) => SCHEDULED_EVENT_KEYS.has(key as ScheduledFunctionEventKey)),
   ) as BlueprintScheduledFunctionResourceEvent

--- a/src/types/functions/event.ts
+++ b/src/types/functions/event.ts
@@ -70,10 +70,16 @@ export interface BlueprintScheduledFunctionExpressionResourceEvent {
 }
 
 /**
+ * Union type of all scheduled function resource events
+ * @category Functions Types
+ */
+export type BlueprintScheduledFunctionResourceEvent = BlueprintScheduledFunctionExplicitResourceEvent
+
+/**
  * Union type of all scheduled function resource event configurations
  * @category Functions Types
  */
-export type BlueprintScheduledFunctionResourceEvent =
+export type BlueprintScheduledFunctionConfigEvent =
   | BlueprintScheduledFunctionExplicitResourceEvent
   | BlueprintScheduledFunctionExpressionResourceEvent
 

--- a/src/types/functions/index.ts
+++ b/src/types/functions/index.ts
@@ -2,6 +2,7 @@ import type {BlueprintResource} from '../../index.js'
 import type {
   BlueprintDocumentFunctionResourceEvent,
   BlueprintMediaLibraryFunctionResourceEvent,
+  BlueprintScheduledFunctionConfigEvent,
   BlueprintScheduledFunctionResourceEvent,
   BlueprintSyncTagInvalidateFunctionResourceEvent,
 } from './event.js'
@@ -154,12 +155,16 @@ export type BlueprintMediaLibraryAssetFunctionConfig = Omit<BlueprintMediaLibrar
  * @category Functions Types
  * @interface
  */
-export type BlueprintScheduledFunctionConfig = Omit<BlueprintScheduledFunctionResource, 'type' | 'src'> & {
+export type BlueprintScheduledFunctionConfig = Omit<BlueprintScheduledFunctionResource, 'type' | 'src' | 'event'> & {
   /**
    * Path to the function source code
    * @defaultValue `functions/${name}`
    */
   src?: string
+  /**
+   * Event configuration specifying when the function is triggered
+   */
+  event: BlueprintScheduledFunctionConfigEvent
 }
 
 /**

--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -7,7 +7,6 @@ import {
   VALID_RUNTIMES,
   validateResource,
 } from '../index.js'
-import {validateScheduledExpression} from '../utils/schedule-parser.js'
 
 type BaseFunctionEventKey = keyof BlueprintFunctionBaseResourceEvent
 const BASE_EVENT_KEYS = new Set<BaseFunctionEventKey>(['on', 'filter', 'projection', 'includeDrafts'])
@@ -242,66 +241,52 @@ function validateScheduledFunctionEvent(event: unknown): BlueprintError[] {
   const errors: BlueprintError[] = []
 
   const hasExpression = 'expression' in event
-  const hasExplicitFields = 'minute' in event || 'hour' in event || 'dayOfMonth' in event || 'month' in event || 'dayOfWeek' in event
 
-  if (hasExpression && hasExplicitFields) {
+  if (hasExpression) {
     errors.push({
       type: 'invalid_property',
-      message: 'Cannot specify both `expression` and explicit cron fields (`minute`, `hour`, `dayOfMonth`, `month`, `dayOfWeek`)',
+      message: 'Cannot specify `expression`. Use `defineScheduledFunction` to convert this to explicit fields',
     })
-  } else if (!hasExpression && !hasExplicitFields) {
+  }
+  if (!('minute' in event)) {
     errors.push({
       type: 'missing_parameter',
-      message: 'Either `expression` or explicit cron fields (`minute`, `hour`, `dayOfMonth`, `month`, `dayOfWeek`) must be provided',
+      message: '`minute` must be provided',
     })
-  } else if (hasExpression) {
-    const expr = (event as {expression: unknown}).expression
-    if (typeof expr !== 'string') {
-      errors.push({type: 'invalid_type', message: '`expression` must be a string'})
-    } else {
-      errors.push(...validateScheduledExpression(expr))
-    }
-  } else if (hasExplicitFields) {
-    if (!('minute' in event)) {
-      errors.push({
-        type: 'missing_parameter',
-        message: '`minute` must be provided',
-      })
-    } else if (typeof event.minute !== 'string') {
-      errors.push({type: 'invalid_type', message: '`minute` must be a string'})
-    }
-    if (!('hour' in event)) {
-      errors.push({
-        type: 'missing_parameter',
-        message: '`hour` must be provided',
-      })
-    } else if (typeof event.hour !== 'string') {
-      errors.push({type: 'invalid_type', message: '`hour` must be a string'})
-    }
-    if (!('dayOfWeek' in event)) {
-      errors.push({
-        type: 'missing_parameter',
-        message: '`dayOfWeek` must be provided',
-      })
-    } else if (typeof event.dayOfWeek !== 'string') {
-      errors.push({type: 'invalid_type', message: '`dayOfWeek` must be a string'})
-    }
-    if (!('month' in event)) {
-      errors.push({
-        type: 'missing_parameter',
-        message: '`month` must be provided',
-      })
-    } else if (typeof event.month !== 'string') {
-      errors.push({type: 'invalid_type', message: '`month` must be a string'})
-    }
-    if (!('dayOfMonth' in event)) {
-      errors.push({
-        type: 'missing_parameter',
-        message: '`dayOfMonth` must be provided',
-      })
-    } else if (typeof event.dayOfMonth !== 'string') {
-      errors.push({type: 'invalid_type', message: '`dayOfMonth` must be a string'})
-    }
+  } else if (typeof event.minute !== 'string') {
+    errors.push({type: 'invalid_type', message: '`minute` must be a string'})
+  }
+  if (!('hour' in event)) {
+    errors.push({
+      type: 'missing_parameter',
+      message: '`hour` must be provided',
+    })
+  } else if (typeof event.hour !== 'string') {
+    errors.push({type: 'invalid_type', message: '`hour` must be a string'})
+  }
+  if (!('dayOfWeek' in event)) {
+    errors.push({
+      type: 'missing_parameter',
+      message: '`dayOfWeek` must be provided',
+    })
+  } else if (typeof event.dayOfWeek !== 'string') {
+    errors.push({type: 'invalid_type', message: '`dayOfWeek` must be a string'})
+  }
+  if (!('month' in event)) {
+    errors.push({
+      type: 'missing_parameter',
+      message: '`month` must be provided',
+    })
+  } else if (typeof event.month !== 'string') {
+    errors.push({type: 'invalid_type', message: '`month` must be a string'})
+  }
+  if (!('dayOfMonth' in event)) {
+    errors.push({
+      type: 'missing_parameter',
+      message: '`dayOfMonth` must be provided',
+    })
+  } else if (typeof event.dayOfMonth !== 'string') {
+    errors.push({type: 'invalid_type', message: '`dayOfMonth` must be a string'})
   }
 
   return errors

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -276,7 +276,7 @@ describe('validateScheduledFunction', () => {
       })
       expect(errors).toContainEqual({
         type: 'invalid_property',
-        message: 'Cannot specify both `expression` and explicit cron fields (`minute`, `hour`, `dayOfMonth`, `month`, `dayOfWeek`)',
+        message: 'Cannot specify `expression`. Use `defineScheduledFunction` to convert this to explicit fields',
       })
     })
 
@@ -301,7 +301,7 @@ describe('validateScheduledFunction', () => {
       })
       expect(errors).toContainEqual({
         type: 'missing_parameter',
-        message: 'Either `expression` or explicit cron fields (`minute`, `hour`, `dayOfMonth`, `month`, `dayOfWeek`) must be provided',
+        message: '`minute` must be provided',
       })
     })
 


### PR DESCRIPTION
### Description

Currently we allow `expression` in scheduled function events but the functions API doesn't allow this. Validation should prevent this.
