### PR TITLE
feat: Defer validation errors until blueprint is defined

### DIFF
--- a/src/definers/blueprints.ts
+++ b/src/definers/blueprints.ts
@@ -55,7 +55,7 @@ import {runValidation} from '../utils/validation.js'
 export function defineBlueprint(blueprintConfig: Partial<Blueprint> & Partial<BlueprintsApiConfig>): BlueprintModule {
   const {organizationId, projectId, stackId, blueprintVersion, resources, values, outputs} = blueprintConfig
 
-  runValidation(() => validateBlueprint(blueprintConfig))
+  runValidation(() => validateBlueprint(blueprintConfig), {throwError: true})
 
   function blueprint(): Blueprint {
     return {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -17,10 +17,19 @@ export function runValidation(validator: () => BlueprintError[], options?: {thro
   collectedErrors.push(...errors)
 }
 
+/**
+ * Gets the current set of errors that were returned during validation when resource definers were invoked.
+ * @returns The errors collected during the validation of resources
+ * @internal
+ */
 export function getCollectedErrors(): BlueprintError[] {
   return collectedErrors
 }
 
+/**
+ * Resets the list of collected errors back to an empty list.
+ * @internal
+ */
 export function resetCollectedErrors() {
   collectedErrors.splice(0, collectedErrors.length)
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,16 +1,28 @@
 import type {BlueprintError} from '../types/errors'
 
+const collectedErrors: BlueprintError[] = []
+
 /**
- * Executes the given validator function and throws a formatted error if any are returned.
+ * Executes the given validator function and throws a formatted error if any are returned and throwError is enabled.
+ * Otherwise collects errors for use later during blueprint validation.
  * @param validator A function that returns a list of validation errors.
  * @internal
  */
-export function runValidation(validator: () => BlueprintError[]) {
+export function runValidation(validator: () => BlueprintError[], options?: {throwError?: boolean}) {
   const errors = validator()
-  if (errors.length > 0) {
+  if (options?.throwError && errors.length > 0) {
     const message = errors.map((err) => err.message).join('\n')
     throw new Error(message)
   }
+  collectedErrors.push(...errors)
+}
+
+export function getCollectedErrors(): BlueprintError[] {
+  return collectedErrors
+}
+
+export function resetCollectedErrors() {
+  collectedErrors.splice(0, collectedErrors.length)
 }
 
 const REFERENCE_PREFIXES = ['$.resources.', '$.values.', '$.parameters.', '$.params.']

--- a/src/validation/blueprints.ts
+++ b/src/validation/blueprints.ts
@@ -17,11 +17,11 @@ export function validateBlueprint(blueprintConfig: unknown): BlueprintError[] {
     const {resources} = blueprintConfig
 
     if (resources && !Array.isArray(resources)) errors.push({type: 'invalid_format', message: '`resources` must be an array'})
-
-    // add any errors that were collected when definers were called
-    errors.push(...getCollectedErrors())
-    resetCollectedErrors()
   }
+
+  // add any errors that were collected when definers were called
+  errors.push(...getCollectedErrors())
+  resetCollectedErrors()
 
   return errors
 }

--- a/src/validation/blueprints.ts
+++ b/src/validation/blueprints.ts
@@ -1,4 +1,5 @@
 import type {BlueprintError} from '../index.js'
+import {getCollectedErrors, resetCollectedErrors} from '../utils/validation.js'
 
 /**
  * Validates that the given input is a valid Blueprint
@@ -16,6 +17,10 @@ export function validateBlueprint(blueprintConfig: unknown): BlueprintError[] {
     const {resources} = blueprintConfig
 
     if (resources && !Array.isArray(resources)) errors.push({type: 'invalid_format', message: '`resources` must be an array'})
+
+    // add any errors that were collected when definers were called
+    errors.push(...getCollectedErrors())
+    resetCollectedErrors()
   }
 
   return errors

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -1,0 +1,5 @@
+import * as index from '../../src/index.js'
+
+export function defineBlueprintForResource(resource: index.BlueprintResource) {
+  index.defineBlueprint({resources: [resource]})
+}

--- a/test/unit/definers/cors.test.ts
+++ b/test/unit/definers/cors.test.ts
@@ -1,6 +1,7 @@
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import * as cors from '../../../src/definers/cors.js'
 import * as index from '../../../src/index.js'
+import {defineBlueprintForResource} from '../../helpers/index.js'
 
 vi.mock(import('../../../src/index.js'), async (importOriginal) => {
   const originalModule = await importOriginal()
@@ -18,10 +19,12 @@ describe('defineCorsOrigin', () => {
   test('should throw an error if validateCorsOrigin returns an error', () => {
     const spy = vi.spyOn(index, 'validateCorsOrigin').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
     expect(() =>
-      cors.defineCorsOrigin({
-        name: 'origin-name',
-        origin: 'http://localhost/',
-      }),
+      defineBlueprintForResource(
+        cors.defineCorsOrigin({
+          name: 'origin-name',
+          origin: 'http://localhost/',
+        }),
+      ),
     ).toThrow(/this is a test/)
 
     expect(spy).toHaveBeenCalledOnce()

--- a/test/unit/definers/dataset.test.ts
+++ b/test/unit/definers/dataset.test.ts
@@ -1,6 +1,7 @@
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import * as datasets from '../../../src/definers/datasets.js'
 import * as index from '../../../src/index.js'
+import {defineBlueprintForResource} from '../../helpers/index.js'
 
 vi.mock(import('../../../src/index.js'), async (importOriginal) => {
   const originalModule = await importOriginal()
@@ -63,10 +64,12 @@ describe('defineDataset', () => {
   test('should throw if validateDataset returns an error', () => {
     const spy = vi.spyOn(index, 'validateDataset').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
     expect(() =>
-      datasets.defineDataset({
-        name: 'dataset-name',
-        aclMode: 'public',
-      }),
+      defineBlueprintForResource(
+        datasets.defineDataset({
+          name: 'dataset-name',
+          aclMode: 'public',
+        }),
+      ),
     ).toThrow(/this is a test/)
 
     expect(spy).toHaveBeenCalledOnce()

--- a/test/unit/definers/functions.test.ts
+++ b/test/unit/definers/functions.test.ts
@@ -1,6 +1,7 @@
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import * as fns from '../../../src/definers/functions.js'
 import * as index from '../../../src/index.js'
+import {defineBlueprintForResource} from '../../helpers/index.js'
 
 vi.mock(import('../../../src/index.js'), async (importOriginal) => {
   const originalModule = await importOriginal()
@@ -30,7 +31,7 @@ describe('defineFunction', () => {
 
     test('should throw an error if validateFunction returns an error', () => {
       const spy = vi.spyOn(index, 'validateFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
-      expect(() => fns.defineFunction({name: 'func-name'})).toThrow('this is a test')
+      expect(() => defineBlueprintForResource(fns.defineFunction({name: 'func-name'}))).toThrow('this is a test')
 
       expect(spy).toHaveBeenCalledOnce()
     })
@@ -111,7 +112,9 @@ describe('defineDocumentFunction', () => {
 
     test('should throw an error if validateDocumentFunction returns an error', () => {
       const spy = vi.spyOn(index, 'validateDocumentFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
-      expect(() => fns.defineDocumentFunction({name: 'test', event: {on: ['publish']}})).toThrow('this is a test')
+      expect(() => defineBlueprintForResource(fns.defineDocumentFunction({name: 'test', event: {on: ['publish']}}))).toThrow(
+        'this is a test',
+      )
 
       expect(spy).toHaveBeenCalledOnce()
     })
@@ -175,7 +178,9 @@ describe('defineMediaLibraryAssetFunction', () => {
     test('should throw an error if validateMediaLibraryAssetFunction returns an error', () => {
       const spy = vi.spyOn(index, 'validateMediaLibraryAssetFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
       expect(() =>
-        fns.defineMediaLibraryAssetFunction({name: 'test', event: {on: ['publish'], resource: {type: 'media-library', id: 'ml1234'}}}),
+        defineBlueprintForResource(
+          fns.defineMediaLibraryAssetFunction({name: 'test', event: {on: ['publish'], resource: {type: 'media-library', id: 'ml1234'}}}),
+        ),
       ).toThrow('this is a test')
 
       expect(spy).toHaveBeenCalledOnce()
@@ -286,7 +291,9 @@ describe('defineScheduledFunction', () => {
     test('should throw an error if validateScheduledFunction returns an error', () => {
       const spy = vi.spyOn(index, 'validateScheduledFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
       expect(() =>
-        fns.defineScheduledFunction({name: 'test', event: {minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'}}),
+        defineBlueprintForResource(
+          fns.defineScheduledFunction({name: 'test', event: {minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'}}),
+        ),
       ).toThrow('this is a test')
 
       expect(spy).toHaveBeenCalledOnce()

--- a/test/unit/definers/project.test.ts
+++ b/test/unit/definers/project.test.ts
@@ -1,6 +1,7 @@
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import * as projects from '../../../src/definers/projects.js'
 import * as index from '../../../src/index.js'
+import {defineBlueprintForResource} from '../../helpers/index.js'
 
 vi.mock(import('../../../src/index.js'), async (importOriginal) => {
   const originalModule = await importOriginal()
@@ -57,9 +58,11 @@ describe('defineProject', () => {
   test('should throw if validateProject returns an error', () => {
     const spy = vi.spyOn(index, 'validateProject').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
     expect(() =>
-      projects.defineProject({
-        name: 'project-name',
-      }),
+      defineBlueprintForResource(
+        projects.defineProject({
+          name: 'project-name',
+        }),
+      ),
     ).toThrow(/this is a test/)
 
     expect(spy).toHaveBeenCalledOnce()

--- a/test/unit/definers/robotTokens.test.ts
+++ b/test/unit/definers/robotTokens.test.ts
@@ -1,6 +1,7 @@
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import * as robotTokens from '../../../src/definers/robotTokens.js'
 import * as index from '../../../src/index.js'
+import {defineBlueprintForResource} from '../../helpers/index.js'
 
 vi.mock(import('../../../src/index.js'), async (importOriginal) => {
   const originalModule = await importOriginal()
@@ -79,16 +80,18 @@ describe('defineRobotToken', () => {
   test('should throw if validateRobotToken returns an error', () => {
     const spy = vi.spyOn(index, 'validateRobotToken').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
     expect(() =>
-      robotTokens.defineRobotToken({
-        name: 'robot-name',
-        memberships: [
-          {
-            resourceType: 'project',
-            resourceId: 'test-project',
-            roleNames: ['test-role'],
-          },
-        ],
-      }),
+      defineBlueprintForResource(
+        robotTokens.defineRobotToken({
+          name: 'robot-name',
+          memberships: [
+            {
+              resourceType: 'project',
+              resourceId: 'test-project',
+              roleNames: ['test-role'],
+            },
+          ],
+        }),
+      ),
     ).toThrow(/this is a test/)
 
     expect(spy).toHaveBeenCalledOnce()

--- a/test/unit/definers/roles.test.ts
+++ b/test/unit/definers/roles.test.ts
@@ -1,6 +1,7 @@
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import * as roles from '../../../src/definers/roles.js'
 import * as index from '../../../src/index.js'
+import {defineBlueprintForResource} from '../../helpers/index.js'
 
 describe('defineRole', () => {
   afterEach(() => {
@@ -10,7 +11,9 @@ describe('defineRole', () => {
   test('should throw an error if validateRole returns an error', () => {
     const spy = vi.spyOn(index, 'validateRole').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
     expect(() =>
-      roles.defineRole({name: 'role-name', title: 'Role Name', appliesToRobots: true, appliesToUsers: true, permissions: []}),
+      defineBlueprintForResource(
+        roles.defineRole({name: 'role-name', title: 'Role Name', appliesToRobots: true, appliesToUsers: true, permissions: []}),
+      ),
     ).toThrow(/this is a test/)
 
     expect(spy).toHaveBeenCalledOnce()

--- a/test/unit/definers/webhooks.test.ts
+++ b/test/unit/definers/webhooks.test.ts
@@ -1,6 +1,7 @@
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import * as webhooks from '../../../src/definers/webhooks.js'
 import * as index from '../../../src/index.js'
+import {defineBlueprintForResource} from '../../helpers/index.js'
 
 describe('defineDocumentWebhook', () => {
   afterEach(() => {
@@ -10,13 +11,15 @@ describe('defineDocumentWebhook', () => {
   test('should throw an error if validateDocumentWebhook returns an error', () => {
     const spy = vi.spyOn(index, 'validateDocumentWebhook').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
     expect(() =>
-      webhooks.defineDocumentWebhook({
-        name: 'webhook-name',
-        url: 'http://localhost/',
-        on: ['create'],
-        dataset: 'abcdefg',
-        apiVersion: 'vX',
-      }),
+      defineBlueprintForResource(
+        webhooks.defineDocumentWebhook({
+          name: 'webhook-name',
+          url: 'http://localhost/',
+          on: ['create'],
+          dataset: 'abcdefg',
+          apiVersion: 'vX',
+        }),
+      ),
     ).toThrow(/this is a test/)
 
     expect(spy).toHaveBeenCalledOnce()

--- a/test/unit/validation/blueprints.test.ts
+++ b/test/unit/validation/blueprints.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from 'vitest'
-import {validateBlueprint} from '../../../src/index.js'
+import {defineCorsOrigin, defineDocumentFunction, validateBlueprint} from '../../../src/index.js'
 
 describe('validateBlueprint', () => {
   test('should return an error if config is falsey', () => {
@@ -23,6 +23,23 @@ describe('validateBlueprint', () => {
     expect(errors).toContainEqual({
       type: 'invalid_format',
       message: '`resources` must be an array',
+    })
+  })
+
+  test('should return errors from other resources validation', () => {
+    const errors = validateBlueprint({
+      resources: [
+        defineCorsOrigin({name: '', origin: ''}),
+        defineDocumentFunction({name: '', event: {resource: {type: 'dataset', id: ''}}}),
+      ],
+    })
+    expect(errors).toContainEqual({
+      type: 'missing_parameter',
+      message: 'CORS Origin name is required',
+    })
+    expect(errors).toContainEqual({
+      type: 'invalid_format',
+      message: '`event.resource.id` must be in the format <projectId>.<datasetName>',
     })
   })
 })


### PR DESCRIPTION
### Description

When creating a blueprint, it's annoying to get a couple errors about oen resource, fix those and then have more errors. This PR fixes that flow by deferring the error throwing until the blueprint is defined.

### Testing

Updated tests and added a helper function to simulate defining the blueprint.
