### PR TITLE
feat: add support for queue functions

### DIFF
--- a/src/definers/functions.ts
+++ b/src/definers/functions.ts
@@ -8,6 +8,10 @@ import {
   type BlueprintMediaLibraryAssetFunctionConfig,
   type BlueprintMediaLibraryAssetFunctionResource,
   type BlueprintMediaLibraryFunctionResourceEvent,
+  type BlueprintQueueFunctionConfig,
+  type BlueprintQueueFunctionConfigEvent,
+  type BlueprintQueueFunctionResource,
+  type BlueprintQueueFunctionResourceEvent,
   type BlueprintScheduledFunctionConfig,
   type BlueprintScheduledFunctionConfigEvent,
   type BlueprintScheduledFunctionExplicitResourceEvent,
@@ -19,6 +23,7 @@ import {
   validateDocumentFunction,
   validateFunction,
   validateMediaLibraryAssetFunction,
+  validateQueueFunction,
   validateScheduledFunction,
   validateSyncTagInvalidateFunction,
 } from '../index.js'
@@ -35,6 +40,8 @@ type ScheduledFunctionEventKey =
   | keyof BlueprintScheduledFunctionExplicitResourceEvent
   | keyof BlueprintScheduledFunctionExpressionResourceEvent
 const SCHEDULED_EVENT_KEYS = new Set<ScheduledFunctionEventKey>(['minute', 'hour', 'dayOfWeek', 'month', 'dayOfMonth', 'expression'])
+type QueueFunctionEventKey = keyof BlueprintQueueFunctionResourceEvent
+const QUEUE_EVENT_KEYS = new Set<QueueFunctionEventKey>(['concurrency', 'fifo', 'dlq'])
 
 /*
  * FUTURE example (move below @example when ready)
@@ -320,6 +327,58 @@ export function defineSyncTagInvalidateFunction(
 }
 
 /**
+ * Defines a function that provide queueing behaviour.
+ *
+ * @remarks
+ * Using the reasonable defaults of concurrency: 1, fifo: true, and dlq: true
+ * ```ts
+ * defineQueueFunction({
+ *   name: 'send-email',
+ * })
+ * ```
+ *
+ * Using the reasonable defaults of concurrency: 1, fifo: true, and dlq: true
+ * ```ts
+ * defineQueueFunction({
+ *   name: 'bustin-caches',
+ *   queue: true,
+ * })
+ * ```
+ *
+ * Specifying a concurrency of 5
+ * ```ts
+ * defineQueueFunction({
+ *   name: 'bustin-caches',
+ *   queue: {
+ *    concurrency: 5,
+ *    fifo: true,
+ *    dlq: true,
+ *  },
+ * })
+ * ```
+ * @public
+ * @alpha Deploying Queue Functions via Blueprints is experimental. This feature is not available publicly yet.
+ * @hidden
+ * @category Definers
+ * @expandType BlueprintQueueFunctionConfig
+ * @param functionConfig The configuration for the queue function
+ * @returns The validated queue function resource
+ */
+export function defineQueueFunction(functionConfig: BlueprintQueueFunctionConfig): BlueprintQueueFunctionResource {
+  const {queue = true} = functionConfig
+
+  const functionResource: BlueprintQueueFunctionResource = {
+    ...defineFunction(functionConfig, {skipValidation: true}),
+    type: 'sanity.function.queue',
+    event: buildQueueFunctionEvent(queue),
+  }
+
+  runValidation(() => validateQueueFunction(functionResource))
+
+  return functionResource
+}
+
+/**
  * Defines a base function resource with common properties.
  *
  * @param functionConfig The configuration for the function
@@ -415,4 +474,21 @@ function cronStringToExplicitEvent(cron: string): BlueprintScheduledFunctionExpl
   }
   const [minute, hour, dayOfMonth, month, dayOfWeek] = parts
   return {minute, hour, dayOfMonth, month, dayOfWeek}
+}
+
+/**
+ * Builds a queue function event configuration.
+ * @param event Queue function event configuration
+ * @returns Cleaned queue function event configuration
+ */
+function buildQueueFunctionEvent(event: BlueprintQueueFunctionConfigEvent): BlueprintQueueFunctionResourceEvent {
+  const defaultEvent = {concurrency: 1, fifo: true, dlq: true}
+  if (typeof event === 'boolean') {
+    return defaultEvent
+  }
+  const userProvidedEvent = Object.fromEntries(Object.entries(event).filter(([key]) => QUEUE_EVENT_KEYS.has(key as QueueFunctionEventKey)))
+  return {
+    ...defaultEvent,
+    ...userProvidedEvent,
+  } as BlueprintQueueFunctionResourceEvent
 }

--- a/src/types/functions/event.ts
+++ b/src/types/functions/event.ts
@@ -84,12 +84,33 @@ export type BlueprintScheduledFunctionConfigEvent =
   | BlueprintScheduledFunctionExpressionResourceEvent
 
 /**
+ * Event configuration for queue functions
+ * @category Functions Types
+ * @alpha
+ * @hidden
+ */
+export interface BlueprintQueueFunctionResourceEvent {
+  concurrency?: number
+  fifo?: boolean
+  dlq?: boolean
+}
+
+export type BlueprintQueueFunctionBooleanResourceEvent = boolean
+
+/**
+ * Union type of all queue function resource event configurations
+ * @category Functions Types
+ */
+export type BlueprintQueueFunctionConfigEvent = BlueprintQueueFunctionBooleanResourceEvent | BlueprintQueueFunctionResourceEvent
+
+/**
  * Union type of all function resource event configurations
  * @category Functions Types
  */
 export type BlueprintFunctionResourceEvent =
   | BlueprintDocumentFunctionResourceEvent
   | BlueprintMediaLibraryFunctionResourceEvent
+  | BlueprintQueueFunctionResourceEvent
   | BlueprintScheduledFunctionResourceEvent
   | BlueprintSyncTagInvalidateFunctionResourceEvent
 

--- a/src/types/functions/index.ts
+++ b/src/types/functions/index.ts
@@ -2,6 +2,8 @@ import type {BlueprintResource} from '../../index.js'
 import type {
   BlueprintDocumentFunctionResourceEvent,
   BlueprintMediaLibraryFunctionResourceEvent,
+  BlueprintQueueFunctionConfigEvent,
+  BlueprintQueueFunctionResourceEvent,
   BlueprintScheduledFunctionConfigEvent,
   BlueprintScheduledFunctionResourceEvent,
   BlueprintSyncTagInvalidateFunctionResourceEvent,
@@ -99,6 +101,17 @@ export interface BlueprintSyncTagInvalidateFunctionResource extends BlueprintBas
   event?: BlueprintSyncTagInvalidateFunctionResourceEvent
 }
 
+/**
+ * A function resource triggered by sync tag invalidate events
+ * @category Functions Types
+ * @alpha
+ * @hidden
+ */
+export interface BlueprintQueueFunctionResource extends BlueprintBaseFunctionResource {
+  type: 'sanity.function.queue'
+  event?: BlueprintQueueFunctionResourceEvent
+}
+
 // --- Function Config Types ---
 
 /**
@@ -182,4 +195,26 @@ export type BlueprintSyncTagInvalidateFunctionConfig = Omit<BlueprintSyncTagInva
    * @defaultValue `functions/${name}`
    */
   src?: string
+}
+
+/**
+ * Configuration for defining a queue function.
+ * @public
+ * @alpha Deploying Queue Functions via Blueprints is experimental. This feature is not available publicly yet.
+ * @hidden
+ * @category Functions Types
+ * @interface
+ */
+export type BlueprintQueueFunctionConfig = Omit<BlueprintQueueFunctionResource, 'type' | 'src' | 'event'> & {
+  /**
+   * Path to the function source code
+   * @defaultValue `functions/${name}`
+   */
+  src?: string
+  /**
+   * Queue configuration. Pass `true` or omit to use defaults (concurrency: 1, fifo: true, dlq: true),
+   * or pass an object to override specific settings.
+   * @defaultValue true
+   */
+  queue?: BlueprintQueueFunctionConfigEvent
 }

--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -340,3 +340,52 @@ export function validateSyncTagInvalidateFunction(functionResource: unknown): Bl
 
   return errors
 }
+
+/**
+ * Validates a queue function resource configuration.
+ * @param functionResource The function resource to validate
+ * @alpha
+ * @hidden
+ * @category Functions Types
+ * @returns Array of validation errors, empty if valid
+ */
+
+export function validateQueueFunction(functionResource: unknown): BlueprintError[] {
+  if (!functionResource) return [{type: 'invalid_value', message: 'Function config must be provided'}]
+  if (typeof functionResource !== 'object') return [{type: 'invalid_type', message: 'Function config must be an object'}]
+
+  const errors: BlueprintError[] = []
+
+  if ('type' in functionResource && functionResource.type !== 'sanity.function.queue') {
+    errors.push({type: 'invalid_value', message: '`type` must be `sanity.function.queue`'})
+  }
+
+  if ('event' in functionResource) {
+    errors.push(...validateQueueFunctionEvent(functionResource.event))
+  }
+
+  errors.push(...validateFunction(functionResource))
+
+  return errors
+}
+
+function validateQueueFunctionEvent(event: unknown): BlueprintError[] {
+  if (!event || typeof event !== 'object') return [{type: 'invalid_type', message: '`event` must be an object'}]
+
+  const errors: BlueprintError[] = []
+
+  if (!('concurrency' in event) || typeof event.concurrency !== 'number') {
+    errors.push({type: 'invalid_type', message: '`event.concurrency` must be a number'})
+  }
+  if ('concurrency' in event && typeof event.concurrency === 'number' && event.concurrency < 1) {
+    errors.push({type: 'invalid_type', message: '`event.concurrency` must be at least 1'})
+  }
+  if (!('fifo' in event) || typeof event.fifo !== 'boolean') {
+    errors.push({type: 'invalid_type', message: '`event.fifo` must be a boolean'})
+  }
+  if (!('dlq' in event) || typeof event.dlq !== 'boolean') {
+    errors.push({type: 'invalid_type', message: '`event.dlq` must be a boolean'})
+  }
+
+  return errors
+}

--- a/test/integration/imports.test.ts
+++ b/test/integration/imports.test.ts
@@ -7,6 +7,7 @@ import {
   defineFunction,
   defineMediaLibraryAssetFunction,
   defineProjectRole,
+  defineQueueFunction,
   defineResource,
   defineRole,
   defineScheduledFunction,
@@ -18,6 +19,7 @@ import {
   validateDocumentWebhook,
   validateFunction,
   validateMediaLibraryAssetFunction,
+  validateQueueFunction,
   validateResource,
   validateRole,
   validateSyncTagInvalidateFunction,
@@ -47,6 +49,10 @@ describe('package imports', () => {
 
   it('should import defineSyncTagInvalidateFunction', () => {
     expect(defineSyncTagInvalidateFunction).toBeInstanceOf(Function)
+  })
+
+  it('should import defineQueueFunction', () => {
+    expect(defineQueueFunction).toBeInstanceOf(Function)
   })
 
   it('should import defineDocumentWebhook', () => {
@@ -91,6 +97,10 @@ describe('package imports', () => {
 
   it('should import validateSyncTagInvalidateFunction', () => {
     expect(validateSyncTagInvalidateFunction).toBeInstanceOf(Function)
+  })
+
+  it('should import validateQueueFunction', () => {
+    expect(validateQueueFunction).toBeInstanceOf(Function)
   })
 
   it('should import validateDocumentWebhook', () => {

--- a/test/integration/resources.typecheck.ts
+++ b/test/integration/resources.typecheck.ts
@@ -18,6 +18,7 @@ import {
   type BlueprintOutput,
   type BlueprintProjectResourceLifecycle,
   type BlueprintProjectRoleResource,
+  type BlueprintQueueFunctionResource,
   type BlueprintResource,
   type BlueprintRoleConfig,
   type BlueprintRoleResource,
@@ -31,6 +32,7 @@ import {
   defineDocumentWebhook,
   defineMediaLibraryAssetFunction,
   defineProjectRole,
+  defineQueueFunction,
   defineRole,
   defineScheduledFunction,
   defineSyncTagInvalidateFunction,
@@ -42,6 +44,7 @@ import {
   validateDocumentWebhook,
   validateFunction,
   validateMediaLibraryAssetFunction,
+  validateQueueFunction,
   validateResource,
   validateRole,
   validateScheduledFunction,
@@ -107,6 +110,11 @@ const fullyQualifiedSyncTagInvalidateFunctionResourceEvent: BlueprintSyncTagInva
 const syncTagInvalidateFunction: BlueprintSyncTagInvalidateFunctionResource = defineSyncTagInvalidateFunction({
   name: 'yoyoyo',
   event: fullyQualifiedSyncTagInvalidateFunctionResourceEvent,
+})
+
+const queueFunction: BlueprintQueueFunctionResource = defineQueueFunction({
+  name: 'stuff',
+  queue: true,
 })
 
 const documentWebhookConfig: BlueprintDocumentWebhookConfig = {
@@ -218,3 +226,4 @@ validateResource(blueprintResource)
 validateRole(roleResource)
 validateScheduledFunction(scheduledFunctionResource)
 validateSyncTagInvalidateFunction(syncTagInvalidateFunction)
+validateQueueFunction(queueFunction)

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -475,3 +475,109 @@ describe('validateSyncTagInvalidateFunction', () => {
     })
   })
 })
+
+describe('validateQueueFunction', () => {
+  describe('happy paths', () => {
+    test('should accept a valid queue function without any optional properties', () => {
+      const errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+      })
+      expect(errors).toStrictEqual([])
+    })
+    test('should accept a valid queue function with default event properties', () => {
+      const errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {concurrency: 1, fifo: true, dlq: true},
+      })
+      expect(errors).toStrictEqual([])
+    })
+    test('should accept a valid queue function with custom concurrency', () => {
+      const errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {concurrency: 5, fifo: false, dlq: false},
+      })
+      expect(errors).toStrictEqual([])
+    })
+  })
+  describe('sad paths', () => {
+    test('should return an error if the type is not `sanity.function.queue`', () => {
+      const errors = functions.validateQueueFunction({type: 'invalid'})
+      expect(errors).toContainEqual({
+        type: 'invalid_value',
+        message: '`type` must be `sanity.function.queue`',
+      })
+    })
+    test('should return an error if event.concurrency is invalid', () => {
+      let errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {fifo: true, dlq: true},
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_type',
+        message: '`event.concurrency` must be a number',
+      })
+      errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {concurrency: 'five', fifo: true, dlq: true},
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_type',
+        message: '`event.concurrency` must be a number',
+      })
+      errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {concurrency: 0, fifo: true, dlq: true},
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_type',
+        message: '`event.concurrency` must be at least 1',
+      })
+    })
+    test('should return an error if event.fifo is invalid', () => {
+      let errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {concurrency: 1, dlq: true},
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_type',
+        message: '`event.fifo` must be a boolean',
+      })
+      errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {concurrency: 1, fifo: 'yes', dlq: true},
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_type',
+        message: '`event.fifo` must be a boolean',
+      })
+    })
+    test('should return an error if event.dlq is invalid', () => {
+      let errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {concurrency: 1, fifo: true},
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_type',
+        message: '`event.dlq` must be a boolean',
+      })
+      errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {concurrency: 1, fifo: true, dlq: 'yes'},
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_type',
+        message: '`event.dlq` must be a boolean',
+      })
+    })
+  })
+})


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This is not the final form that defining a queue will take. Eventually it will be provided via `defineFunction`. For now I'm adding this sugar method `defineQueue` so that I can get the necessary types into `@sanity/blueprints` so that I can add queues to `blueprints-resource-function`.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

There are 3 ways to use the queue definer:

```javascript
defineQueueFunction({
   name: 'send-email',
})

defineQueueFunction({
   name: 'bustin-caches',
   queue: true,
})

defineQueueFunction({
   name: 'bustin-caches',
   queue: {
     concurrency: 5,
     fifo: true,
     dlq: true,
   },
})
```

The `queue` property here gets converted to an `event` when `buildQueueFunctionEvent` is called. This will get converted to a `rule` when it is posted to the functions service.


### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Added new tests to cover the new definer function.