### PR TITLE
fix: better cron validation messages

### DIFF
--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -15,6 +15,16 @@ const DOCUMENT_EVENT_KEYS = new Set<DocumentFunctionEventKey>(['includeAllVersio
 type MediaLibraryFunctionEventKey = keyof BlueprintMediaLibraryFunctionResourceEvent
 const MEDIA_LIBRARY_EVENT_KEYS = new Set<MediaLibraryFunctionEventKey>(['resource', ...BASE_EVENT_KEYS.values()])
 
+const MINUTES = /^(\*(\/([1-5]?\d))?|([0-5]?\d)(-[0-5]?\d)?(\/([1-5]?\d))?)(,(\*(\/([1-5]?\d))?|([0-5]?\d)(-[0-5]?\d)?(\/([1-5]?\d))?))*$/
+const HOURS =
+  /^(\*(\/([1-9]|1\d|2[0-3]))?|([01]?\d|2[0-3])(-([01]?\d|2[0-3]))?(\/([1-9]|1\d|2[0-3]))?)(,(\*(\/([1-9]|1\d|2[0-3]))?|([01]?\d|2[0-3])(-([01]?\d|2[0-3]))?(\/([1-9]|1\d|2[0-3]))?))*$/
+const DAY_OF_MONTH =
+  /^(\*(\/([1-9]|[12]\d|3[01]))?|([1-9]|[12]\d|3[01])(-([1-9]|[12]\d|3[01]))?(\/([1-9]|[12]\d|3[01]))?)(,(\*(\/([1-9]|[12]\d|3[01]))?|([1-9]|[12]\d|3[01])(-([1-9]|[12]\d|3[01]))?(\/([1-9]|[12]\d|3[01]))?))*$/
+const MONTH =
+  /^(\*(\/([1-9]|1[0-2]))?|([1-9]|1[0-2]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-([1-9]|1[0-2]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?(\/([1-9]|1[0-2]))?)(,(\*(\/([1-9]|1[0-2]))?|([1-9]|1[0-2]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-([1-9]|1[0-2]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?(\/([1-9]|1[0-2]))?))*$/i
+const DAY_OF_WEEK =
+  /^(\*(\/([0-7]))?|([0-7]|SUN|MON|TUE|WED|THU|FRI|SAT)(-([0-7]|SUN|MON|TUE|WED|THU|FRI|SAT))?(\/([0-7]))?)(,(\*(\/([0-7]))?|([0-7]|SUN|MON|TUE|WED|THU|FRI|SAT)(-([0-7]|SUN|MON|TUE|WED|THU|FRI|SAT))?(\/([0-7]))?))*$/i
+
 /**
  * Validates a document function resource configuration.
  * Checks that the function has a valid event configuration, correct type, and all required base properties.
@@ -255,6 +265,18 @@ function validateScheduledFunctionEvent(event: unknown): BlueprintError[] {
     })
   } else if (typeof event.minute !== 'string') {
     errors.push({type: 'invalid_type', message: '`minute` must be a string'})
+  } else if (!MINUTES.test(event.minute)) {
+    errors.push({
+      type: 'invalid_value',
+      message: `Invalid minute field: "${event.minute}"
+
+The minute field must be:
+- A number from 0 to 59
+- A range like 0-10
+- A step value like */5
+- A list like 0,15,30,45
+`,
+    })
   }
   if (!('hour' in event)) {
     errors.push({
@@ -263,22 +285,18 @@ function validateScheduledFunctionEvent(event: unknown): BlueprintError[] {
     })
   } else if (typeof event.hour !== 'string') {
     errors.push({type: 'invalid_type', message: '`hour` must be a string'})
-  }
-  if (!('dayOfWeek' in event)) {
+  } else if (!HOURS.test(event.hour)) {
     errors.push({
-      type: 'missing_parameter',
-      message: '`dayOfWeek` must be provided',
+      type: 'invalid_value',
+      message: `Invalid hour field: "${event.hour}"
+
+The hour field must be:
+- A number from 0 to 23
+- A range like 9-17
+- A step value like */2
+- A list like 0,6,12,18
+`,
     })
-  } else if (typeof event.dayOfWeek !== 'string') {
-    errors.push({type: 'invalid_type', message: '`dayOfWeek` must be a string'})
-  }
-  if (!('month' in event)) {
-    errors.push({
-      type: 'missing_parameter',
-      message: '`month` must be provided',
-    })
-  } else if (typeof event.month !== 'string') {
-    errors.push({type: 'invalid_type', message: '`month` must be a string'})
   }
   if (!('dayOfMonth' in event)) {
     errors.push({
@@ -287,6 +305,60 @@ function validateScheduledFunctionEvent(event: unknown): BlueprintError[] {
     })
   } else if (typeof event.dayOfMonth !== 'string') {
     errors.push({type: 'invalid_type', message: '`dayOfMonth` must be a string'})
+  } else if (!DAY_OF_MONTH.test(event.dayOfMonth)) {
+    errors.push({
+      type: 'invalid_value',
+      message: `Invalid dayOfMonth field: "${event.dayOfMonth}"
+
+The day-of-month field must be:
+- A number from 1 to 31
+- A range like 1-15
+- A step value like */2
+- A list like 1,15,31
+`,
+    })
+  }
+  if (!('month' in event)) {
+    errors.push({
+      type: 'missing_parameter',
+      message: '`month` must be provided',
+    })
+  } else if (typeof event.month !== 'string') {
+    errors.push({type: 'invalid_type', message: '`month` must be a string'})
+  } else if (!MONTH.test(event.month)) {
+    errors.push({
+      type: 'invalid_value',
+      message: `Invalid month field: "${event.month}"
+
+The month field must be:
+- A number from 1 to 12
+- A range like 1-6
+- A step value like */2
+- A list like 1,4,7,10
+- A month name like JAN or OCT-DEC
+`,
+    })
+  }
+  if (!('dayOfWeek' in event)) {
+    errors.push({
+      type: 'missing_parameter',
+      message: '`dayOfWeek` must be provided',
+    })
+  } else if (typeof event.dayOfWeek !== 'string') {
+    errors.push({type: 'invalid_type', message: '`dayOfWeek` must be a string'})
+  } else if (!DAY_OF_WEEK.test(event.dayOfWeek)) {
+    errors.push({
+      type: 'invalid_value',
+      message: `Invalid dayOfWeek field: "${event.dayOfWeek}"
+
+The day-of-week field must be:
+- A number from 0 to 7
+- Sunday can be specified using 0 or 7
+- A range like MON-FRI
+- A step value like */2
+- A list like MON,WED,FRI
+`,
+    })
   }
 
   return errors

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -252,6 +252,72 @@ describe('validateScheduledFunction', () => {
       expect(errors).toHaveLength(0)
     })
 
+    test.each(['*', '0', '59', '0-30', '*/5', '0-30/5', '0,15,30,45', '5,*/15'])('should accept valid minute expression %s', (minute) => {
+      const errors = functions.validateScheduledFunction({
+        name: 'test',
+        type: 'sanity.function.cron',
+        event: {...validEvent, minute},
+      })
+      expect(errors).toHaveLength(0)
+    })
+
+    test.each(['*', '0', '23', '0-23', '*/2', '0-12/3', '0,6,12,18'])('should accept valid hour expression %s', (hour) => {
+      const errors = functions.validateScheduledFunction({
+        name: 'test',
+        type: 'sanity.function.cron',
+        event: {...validEvent, hour},
+      })
+      expect(errors).toHaveLength(0)
+    })
+
+    test.each(['*', '1', '31', '1-15', '*/2', '1-15/2', '1,15,30'])('should accept valid dayOfMonth expression %s', (dayOfMonth) => {
+      const errors = functions.validateScheduledFunction({
+        name: 'test',
+        type: 'sanity.function.cron',
+        event: {...validEvent, dayOfMonth},
+      })
+      expect(errors).toHaveLength(0)
+    })
+
+    test.each([
+      '*',
+      '1',
+      '12',
+      'JAN',
+      'DEC',
+      'JAN-MAR',
+      'jan-mar',
+      '*/3',
+      '1,6,12',
+      'JAN,JUL',
+    ])('should accept valid month expression %s', (month) => {
+      const errors = functions.validateScheduledFunction({
+        name: 'test',
+        type: 'sanity.function.cron',
+        event: {...validEvent, month},
+      })
+      expect(errors).toHaveLength(0)
+    })
+
+    test.each([
+      '*',
+      '0',
+      '7',
+      'SUN',
+      'SAT',
+      'MON-FRI',
+      'mon-fri',
+      '*/2',
+      '1,3,5',
+    ])('should accept valid dayOfWeek expression %s', (dayOfWeek) => {
+      const errors = functions.validateScheduledFunction({
+        name: 'test',
+        type: 'sanity.function.cron',
+        event: {...validEvent, dayOfWeek},
+      })
+      expect(errors).toHaveLength(0)
+    })
+
     test.each([
       'UTC',
       'America/New_York',
@@ -414,6 +480,130 @@ describe('validateScheduledFunction', () => {
         event: {minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: 1},
       })
       expect(errors).toContainEqual({type: 'invalid_type', message: '`dayOfWeek` must be a string'})
+    })
+
+    test.each([
+      '60',
+      '-1',
+      'abc',
+      '*/60',
+      '60-70',
+      '0-60',
+      '0,60',
+      '*/',
+      '5/',
+      ' ',
+      '*  *',
+    ])('should return an error for invalid minute expression %s', (minute) => {
+      const errors = functions.validateScheduledFunction({
+        name: 'test',
+        type: 'sanity.function.cron',
+        event: {...validEvent, minute},
+      })
+      expect(errors).toContainEqual(
+        expect.objectContaining({
+          type: 'invalid_value',
+          message: expect.stringMatching(/Invalid minute field:/),
+        }),
+      )
+    })
+
+    test.each([
+      '24',
+      '25',
+      '-1',
+      'abc',
+      '*/0',
+      '*/24',
+      '0-24',
+      '24-25',
+      '0,24',
+    ])('should return an error for invalid hour expression %s', (hour) => {
+      const errors = functions.validateScheduledFunction({
+        name: 'test',
+        type: 'sanity.function.cron',
+        event: {...validEvent, hour},
+      })
+      expect(errors).toContainEqual(
+        expect.objectContaining({
+          type: 'invalid_value',
+          message: expect.stringMatching(/Invalid hour field:/),
+        }),
+      )
+    })
+
+    test.each([
+      '0',
+      '32',
+      '-1',
+      'abc',
+      '*/0',
+      '*/32',
+      '0-15',
+      '1-32',
+      '0,15',
+    ])('should return an error for invalid dayOfMonth expression %s', (dayOfMonth) => {
+      const errors = functions.validateScheduledFunction({
+        name: 'test',
+        type: 'sanity.function.cron',
+        event: {...validEvent, dayOfMonth},
+      })
+      expect(errors).toContainEqual(
+        expect.objectContaining({
+          type: 'invalid_value',
+          message: expect.stringMatching(/Invalid dayOfMonth field:/),
+        }),
+      )
+    })
+
+    test.each([
+      '0',
+      '13',
+      '-1',
+      'abc',
+      'JANUARY',
+      'XYZ',
+      '*/0',
+      '*/13',
+      '0-6',
+      '1-13',
+      'JAN-XYZ',
+    ])('should return an error for invalid month expression %s', (month) => {
+      const errors = functions.validateScheduledFunction({
+        name: 'test',
+        type: 'sanity.function.cron',
+        event: {...validEvent, month},
+      })
+      expect(errors).toContainEqual(
+        expect.objectContaining({
+          type: 'invalid_value',
+          message: expect.stringMatching(/Invalid month field:/),
+        }),
+      )
+    })
+
+    test.each([
+      '8',
+      '9',
+      '-1',
+      'abc',
+      'MONDAY',
+      'XYZ',
+      '*/8',
+      '0-8',
+      'MON-XYZ',
+    ])('should return an error for invalid dayOfWeek expression %s', (dayOfWeek) => {
+      const errors = functions.validateScheduledFunction({
+        name: 'test',
+        type: 'sanity.function.cron',
+        event: {...validEvent, dayOfWeek},
+      })
+      expect(errors).toContainEqual(
+        expect.objectContaining({
+          type: 'invalid_value',
+          message: expect.stringMatching(/Invalid dayOfWeek field:/),
+        }),
+      )
     })
   })
 })


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

We had a customer try and create a schedule function with a minute field of "*/60" which is invalid. Minutes can be in the range of 0-59. The Functions service rightly rejected it but this PR does more up front validation with nice error messages:

```
sanity blueprints plan
    Error: Could not parse Blueprint manifest: sanity.blueprint.ts
    Error: Invalid minute field: "*/65"

    The minute field must be:
    - A number from 0 to 59
    - A range like 0-10
    - A step value like */5
    - A list like 0,15,30,45
```

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Good luck reading the regex but they are the same ones we use in the Functions service.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Added more unit tests and built a local CLI with this code and was able to test manually.