### PR TITLE
feat: Add validation for function env

### DIFF
--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -136,6 +136,20 @@ export function validateFunction(functionResource: unknown): BlueprintError[] {
     }
   }
 
+  if ('env' in functionResource) {
+    if (typeof functionResource.env !== 'object' || functionResource.env === null) {
+      errors.push({type: 'invalid_type', message: `\`env\` must be an object`})
+    } else {
+      for (const [key, value] of Object.entries(functionResource.env)) {
+        if (typeof value !== 'string') {
+          errors.push({type: 'invalid_type', message: `\`env[${key}]\` must be a string`})
+        } else if (value.length === 0) {
+          errors.push({type: 'invalid_value', message: `\`env[${key}]\` must not be empty`})
+        }
+      }
+    }
+  }
+
   return errors
 }
 

--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -143,8 +143,6 @@ export function validateFunction(functionResource: unknown): BlueprintError[] {
       for (const [key, value] of Object.entries(functionResource.env)) {
         if (typeof value !== 'string') {
           errors.push({type: 'invalid_type', message: `\`env[${key}]\` must be a string`})
-        } else if (value.length === 0) {
-          errors.push({type: 'invalid_value', message: `\`env[${key}]\` must not be empty`})
         }
       }
     }

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -100,11 +100,6 @@ describe('validateFunction', () => {
       const errors = functions.validateFunction({name: 'test', type: 'test', env: {key: 1}})
       expect(errors).toContainEqual({type: 'invalid_type', message: '`env[key]` must be a string'})
     })
-
-    test('should return an error if env[key] is empty', () => {
-      const errors = functions.validateFunction({name: 'test', type: 'test', env: {key: ''}})
-      expect(errors).toContainEqual({type: 'invalid_value', message: '`env[key]` must not be empty'})
-    })
   })
 })
 

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -90,6 +90,21 @@ describe('validateFunction', () => {
       const errors = functions.validateFunction({name: 'test', type: 'test', runtime: 'python'})
       expect(errors).toContainEqual({type: 'invalid_value', message: `\`runtime\` must be one of ${index.VALID_RUNTIMES.join(', ')}`})
     })
+
+    test('should return an error if env is not an object', () => {
+      const errors = functions.validateFunction({name: 'test', type: 'test', env: 'string'})
+      expect(errors).toContainEqual({type: 'invalid_type', message: '`env` must be an object'})
+    })
+
+    test('should return an error if env[key] is not a string', () => {
+      const errors = functions.validateFunction({name: 'test', type: 'test', env: {key: 1}})
+      expect(errors).toContainEqual({type: 'invalid_type', message: '`env[key]` must be a string'})
+    })
+
+    test('should return an error if env[key] is empty', () => {
+      const errors = functions.validateFunction({name: 'test', type: 'test', env: {key: ''}})
+      expect(errors).toContainEqual({type: 'invalid_value', message: '`env[key]` must not be empty'})
+    })
   })
 })
 


### PR DESCRIPTION
### Description

Currently there is no validation for the `env` property of the function definition. This PR adds that enforcing the shape to be a map of strings to string values with no empty values to prevent missing env vars.

### Testing

Added new tests for all error cases
