### PR TITLE
fix: Allow undefined function env

### DIFF
--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -136,7 +136,7 @@ export function validateFunction(functionResource: unknown): BlueprintError[] {
     }
   }
 
-  if ('env' in functionResource) {
+  if ('env' in functionResource && typeof functionResource.env !== 'undefined') {
     if (typeof functionResource.env !== 'object' || functionResource.env === null) {
       errors.push({type: 'invalid_type', message: `\`env\` must be an object`})
     } else {

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -12,6 +12,10 @@ describe('validateFunction', () => {
       const errors = functions.validateFunction({name: 'test-function', type: 'test'})
       expect(errors).toHaveLength(0)
     })
+    test('should accept a function with undefined env', () => {
+      const errors = functions.validateFunction({name: 'test-function', type: 'test', env: undefined})
+      expect(errors).toHaveLength(0)
+    })
   })
   describe('sad paths', () => {
     test('should return an error if validateResource returns an error', () => {


### PR DESCRIPTION
### Description

This PR fixes a bug where `env` would get set to undefined via the definer function but would then fail the validation.

### Testing

Added a new happy path test to make sure this works
