### PR TITLE
fix: Allow references in event resource id

### DIFF
--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -7,6 +7,7 @@ import {
   VALID_RUNTIMES,
   validateResource,
 } from '../index.js'
+import {isReference} from '../utils/validation.js'
 
 type BaseFunctionEventKey = keyof BlueprintFunctionBaseResourceEvent
 const BASE_EVENT_KEYS = new Set<BaseFunctionEventKey>(['on', 'filter', 'projection', 'includeDrafts'])
@@ -185,7 +186,12 @@ function validateFunctionEventResourceDataset(event: unknown): BlueprintError[] 
   if (!resource || typeof resource !== 'object') return [{type: 'invalid_value', message: '`event.resource` must be an object'}]
   if (!('type' in resource) || !resource.type || resource.type !== 'dataset')
     errors.push({type: 'invalid_value', message: '`event.resource.type` must be "dataset"'})
-  if (!('id' in resource) || !resource.id || typeof resource.id !== 'string' || resource.id.split('.').length !== 2)
+  if (
+    !('id' in resource) ||
+    !resource.id ||
+    typeof resource.id !== 'string' ||
+    !(isReference(resource.id) || resource.id.split('.').length === 2)
+  )
     errors.push({type: 'invalid_format', message: '`event.resource.id` must be in the format <projectId>.<datasetName>'})
   return errors
 }

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -121,6 +121,20 @@ describe('validateDocumentFunction', () => {
       })
       expect(errors).toHaveLength(0)
     })
+    test('should accept a function with a reference as the resource id', () => {
+      const errors = functions.validateDocumentFunction({
+        name: 'test',
+        type: 'sanity.function.document',
+        event: {
+          filter: '_type == "post"',
+          resource: {
+            type: 'dataset',
+            id: `$.resources.test-dataset.resourceId`,
+          },
+        },
+      })
+      expect(errors).toHaveLength(0)
+    })
   })
   describe('sad paths', () => {
     test('should return an error if validateResource returns an error', () => {
@@ -636,6 +650,14 @@ describe('validateSyncTagInvalidateFunction', () => {
         name: 'test',
         type: 'sanity.function.sync-tag-invalidate',
         event: {resource: {type: 'dataset', id: 'myProj.myDataset'}},
+      })
+      expect(errors).toStrictEqual([])
+    })
+    test('should accept a function with a reference as the resource id', () => {
+      const errors = functions.validateSyncTagInvalidateFunction({
+        name: 'test',
+        type: 'sanity.function.sync-tag-invalidate',
+        event: {resource: {type: 'dataset', id: '$.resources.test-dataset.resourceId'}},
       })
       expect(errors).toStrictEqual([])
     })


### PR DESCRIPTION
### Description

We currently don't allow references in the event resource id but there's a new property on dataset resources (`resourceId`) that would be useful here. This PR changes the logic to allow references.

### What to review

Ensure my boolean logic matches expectations.

### Testing

Wrote new tests for functions that use the resource id validation.
