### PR TITLE
feat: add support for event functions

### DIFF
--- a/src/definers/functions.ts
+++ b/src/definers/functions.ts
@@ -4,6 +4,8 @@ import {
   type BlueprintDocumentFunctionConfig,
   type BlueprintDocumentFunctionResource,
   type BlueprintDocumentFunctionResourceEvent,
+  type BlueprintEventFunctionConfig,
+  type BlueprintEventFunctionResource,
   type BlueprintFunctionBaseResourceEvent,
   type BlueprintMediaLibraryAssetFunctionConfig,
   type BlueprintMediaLibraryAssetFunctionResource,
@@ -371,6 +373,35 @@ export function defineQueueFunction(functionConfig: BlueprintQueueFunctionConfig
     ...defineFunction(functionConfig, {skipValidation: true}),
     type: 'sanity.function.queue',
     event: buildQueueFunctionEvent(queue),
+  }
+
+  runValidation(() => validateQueueFunction(functionResource))
+
+  return functionResource
+}
+
+/**
+ * Defines a function that provide event behaviour.
+ *
+ * @remarks
+ * A barebones event function
+ * ```ts
+ * defineEventFunction({
+ *   name: 'send-email',
+ * })
+ * ```
+ * @public
+ * @alpha Deploying Event Functions via Blueprints is experimental. This feature is not available publicly yet.
+ * @hidden
+ * @category Definers
+ * @expandType BlueprintEventFunctionConfig
+ * @param functionConfig The configuration for the queue function
+ * @returns The validated event function resource
+ */
+export function defineEventFunction(functionConfig: BlueprintEventFunctionConfig): BlueprintEventFunctionResource {
+  const functionResource: BlueprintEventFunctionResource = {
+    ...defineFunction(functionConfig, {skipValidation: true}),
+    type: 'sanity.function.event',
   }
 
   runValidation(() => validateQueueFunction(functionResource))

--- a/src/types/functions/index.ts
+++ b/src/types/functions/index.ts
@@ -112,6 +112,16 @@ export interface BlueprintQueueFunctionResource extends BlueprintBaseFunctionRes
   event?: BlueprintQueueFunctionResourceEvent
 }
 
+/**
+ * A function resource triggered by another function
+ * @category Functions Types
+ * @alpha
+ * @hidden
+ */
+export interface BlueprintEventFunctionResource extends BlueprintBaseFunctionResource {
+  type: 'sanity.function.event'
+}
+
 // --- Function Config Types ---
 
 /**
@@ -217,4 +227,20 @@ export type BlueprintQueueFunctionConfig = Omit<BlueprintQueueFunctionResource, 
    * @defaultValue true
    */
   queue?: BlueprintQueueFunctionConfigEvent
+}
+
+/**
+ * Configuration for defining an event function.
+ * @public
+ * @alpha Deploying Queue Functions via Blueprints is experimental. This feature is not available publicly yet.
+ * @hidden
+ * @category Functions Types
+ * @interface
+ */
+export type BlueprintEventFunctionConfig = Omit<BlueprintEventFunctionResource, 'type' | 'src'> & {
+  /**
+   * Path to the function source code
+   * @defaultValue `functions/${name}`
+   */
+  src?: string
 }

--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -473,3 +473,27 @@ function validateQueueFunctionEvent(event: unknown): BlueprintError[] {
 
   return errors
 }
+
+/**
+ * Validates a event function resource configuration.
+ * @param functionResource The function resource to validate
+ * @alpha
+ * @hidden
+ * @category Functions Types
+ * @returns Array of validation errors, empty if valid
+ */
+
+export function validateEventFunction(functionResource: unknown): BlueprintError[] {
+  if (!functionResource) return [{type: 'invalid_value', message: 'Function config must be provided'}]
+  if (typeof functionResource !== 'object') return [{type: 'invalid_type', message: 'Function config must be an object'}]
+
+  const errors: BlueprintError[] = []
+
+  if ('type' in functionResource && functionResource.type !== 'sanity.function.event') {
+    errors.push({type: 'invalid_value', message: '`type` must be `sanity.function.event`'})
+  }
+
+  errors.push(...validateFunction(functionResource))
+
+  return errors
+}

--- a/test/integration/imports.test.ts
+++ b/test/integration/imports.test.ts
@@ -4,6 +4,7 @@ import {
   defineDataset,
   defineDocumentFunction,
   defineDocumentWebhook,
+  defineEventFunction,
   defineFunction,
   defineMediaLibraryAssetFunction,
   defineProjectRole,
@@ -17,6 +18,7 @@ import {
   validateDataset,
   validateDocumentFunction,
   validateDocumentWebhook,
+  validateEventFunction,
   validateFunction,
   validateMediaLibraryAssetFunction,
   validateQueueFunction,
@@ -53,6 +55,10 @@ describe('package imports', () => {
 
   it('should import defineQueueFunction', () => {
     expect(defineQueueFunction).toBeInstanceOf(Function)
+  })
+
+  it('should import defineEventFunction', () => {
+    expect(defineEventFunction).toBeInstanceOf(Function)
   })
 
   it('should import defineDocumentWebhook', () => {
@@ -101,6 +107,10 @@ describe('package imports', () => {
 
   it('should import validateQueueFunction', () => {
     expect(validateQueueFunction).toBeInstanceOf(Function)
+  })
+
+  it('should import validateEventFunction', () => {
+    expect(validateEventFunction).toBeInstanceOf(Function)
   })
 
   it('should import validateDocumentWebhook', () => {

--- a/test/integration/resources.typecheck.ts
+++ b/test/integration/resources.typecheck.ts
@@ -10,6 +10,7 @@ import {
   type BlueprintDocumentFunctionResourceEvent,
   type BlueprintDocumentWebhookConfig,
   type BlueprintDocumentWebhookResource,
+  type BlueprintEventFunctionResource,
   // type BlueprintFunctionBaseResourceEvent,
   // type BlueprintFunctionResourceEvent,
   type BlueprintMediaLibraryAssetFunctionResource,
@@ -30,6 +31,7 @@ import {
   defineDataset,
   defineDocumentFunction,
   defineDocumentWebhook,
+  defineEventFunction,
   defineMediaLibraryAssetFunction,
   defineProjectRole,
   defineQueueFunction,
@@ -42,6 +44,7 @@ import {
   validateDataset,
   validateDocumentFunction,
   validateDocumentWebhook,
+  validateEventFunction,
   validateFunction,
   validateMediaLibraryAssetFunction,
   validateQueueFunction,
@@ -115,6 +118,10 @@ const syncTagInvalidateFunction: BlueprintSyncTagInvalidateFunctionResource = de
 const queueFunction: BlueprintQueueFunctionResource = defineQueueFunction({
   name: 'stuff',
   queue: true,
+})
+
+const eventFunction: BlueprintEventFunctionResource = defineEventFunction({
+  name: 'event-stuff',
 })
 
 const documentWebhookConfig: BlueprintDocumentWebhookConfig = {
@@ -227,3 +234,4 @@ validateRole(roleResource)
 validateScheduledFunction(scheduledFunctionResource)
 validateSyncTagInvalidateFunction(syncTagInvalidateFunction)
 validateQueueFunction(queueFunction)
+validateEventFunction(eventFunction)

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -785,3 +785,24 @@ describe('validateQueueFunction', () => {
     })
   })
 })
+
+describe('validateEventFunction', () => {
+  describe('happy paths', () => {
+    test('should accept a valid event function without any optional properties', () => {
+      const errors = functions.validateEventFunction({
+        name: 'test',
+        type: 'sanity.function.event',
+      })
+      expect(errors).toStrictEqual([])
+    })
+  })
+  describe('sad paths', () => {
+    test('should return an error if the type is not `sanity.function.event`', () => {
+      const errors = functions.validateEventFunction({type: 'invalid'})
+      expect(errors).toContainEqual({
+        type: 'invalid_value',
+        message: '`type` must be `sanity.function.event`',
+      })
+    })
+  })
+})


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This is a step towards the unified `defineFunction`. For now I'm adding this sugar method `defineEventFunction` so that I can get the necessary types into `@sanity/blueprints` so that I can add events to `blueprints-resource-function`. These will be generic events without queue semantics.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

```javascript
defineEventFunction({
   name: 'send-email',
})
```

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Added new tests to cover the new definer function.