### PR TITLE
fix: better type hinting

### DIFF
--- a/src/definers/functions.ts
+++ b/src/definers/functions.ts
@@ -396,7 +396,7 @@ export function defineQueueFunction(functionConfig: BlueprintQueueFunctionConfig
  * @hidden
  * @category Definers
  * @expandType BlueprintEventFunctionConfig
- * @param functionConfig The configuration for the queue function
+ * @param functionConfig The configuration for the event function
  * @returns The validated event function resource
  */
 export function defineEventFunction(functionConfig: BlueprintEventFunctionConfig): BlueprintEventFunctionResource {

--- a/src/types/functions/event.ts
+++ b/src/types/functions/event.ts
@@ -95,13 +95,11 @@ export interface BlueprintQueueFunctionResourceEvent {
   dlq?: boolean
 }
 
-export type BlueprintQueueFunctionBooleanResourceEvent = boolean
-
 /**
  * Union type of all queue function resource event configurations
  * @category Functions Types
  */
-export type BlueprintQueueFunctionConfigEvent = BlueprintQueueFunctionBooleanResourceEvent | BlueprintQueueFunctionResourceEvent
+export type BlueprintQueueFunctionConfigEvent = true | BlueprintQueueFunctionResourceEvent
 
 /**
  * Union type of all function resource event configurations

--- a/src/types/functions/index.ts
+++ b/src/types/functions/index.ts
@@ -222,8 +222,13 @@ export type BlueprintQueueFunctionConfig = Omit<BlueprintQueueFunctionResource, 
    */
   src?: string
   /**
-   * Queue configuration. Pass `true` or omit to use defaults (concurrency: 1, fifo: true, dlq: true),
-   * or pass an object to override specific settings.
+   * Queue configuration.
+   *
+   * Omit this property or set it to `true` to use the defaults:
+   * concurrency: 1, fifo: true, dlq: true.
+   *
+   * Provide an object to override specific settings.
+   *
    * @defaultValue true
    */
   queue?: BlueprintQueueFunctionConfigEvent


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Minor tweak to the `BlueprintQueueFunctionConfigEvent` type as the valid values should be `true` or `BlueprintQueueFunctionResourceEvent`. The way it was set it would accept `false` which should not be allowed.
