### PR TITLE
feat: add defineWorkflow definer

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,18 +59,6 @@ export default defineBlueprint({
         roleNames: ['developer'],
       }],
     }),
-    
-    defineWorkflow({
-      name: 'my-workflow',
-      displayName: 'My Document Workflow',
-      event: {
-        on: ['create', 'update'],
-        filter: "_type == 'post'",
-      },
-      concurrency: 1,
-      debounce: 5,
-      debounceKey: 'document._id',
-    })
   ],
 })
 ```
@@ -86,5 +74,5 @@ export default defineBlueprint({
 | `defineDocumentWebhook` β | Webhook triggered by document changes |
 | `defineRole` β | Custom role with permissions |
 | `defineRobotToken` β | Robot token for automated access |
-| `defineWorkflow` β | Workflow for managing document events |
+
 Each definer validates its input at call time and returns a typed resource object. See the [reference docs](https://reference.sanity.io/_sanity/blueprints) for full configuration details and additional resource types.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ import {
   defineDocumentWebhook,
   defineRobotToken,
   defineRole,
+  defineWorkflow,
 } from '@sanity/blueprints'
 
 export default defineBlueprint({
@@ -58,6 +59,18 @@ export default defineBlueprint({
         roleNames: ['developer'],
       }],
     }),
+    
+    defineWorkflow({
+      name: 'my-workflow',
+      displayName: 'My Document Workflow',
+      event: {
+        on: ['create', 'update'],
+        filter: "_type == 'post'",
+      },
+      concurrency: 1,
+      debounce: 5,
+      debounceKey: 'document._id',
+    })
   ],
 })
 ```
@@ -73,5 +86,5 @@ export default defineBlueprint({
 | `defineDocumentWebhook` β | Webhook triggered by document changes |
 | `defineRole` β | Custom role with permissions |
 | `defineRobotToken` β | Robot token for automated access |
-
+| `defineWorkflow` β | Workflow for managing document events |
 Each definer validates its input at call time and returns a typed resource object. See the [reference docs](https://reference.sanity.io/_sanity/blueprints) for full configuration details and additional resource types.

--- a/src/definers/functions.ts
+++ b/src/definers/functions.ts
@@ -22,6 +22,8 @@ import {
   type BlueprintScheduledFunctionResourceEvent,
   type BlueprintSyncTagInvalidateFunctionConfig,
   type BlueprintSyncTagInvalidateFunctionResource,
+  type BlueprintWorkflowFunctionConfig,
+  type BlueprintWorkflowFunctionResource,
   validateDocumentFunction,
   validateEventFunction,
   validateFunction,
@@ -29,6 +31,7 @@ import {
   validateQueueFunction,
   validateScheduledFunction,
   validateSyncTagInvalidateFunction,
+  validateWorkflowFunction,
 } from '../index.js'
 import {parseScheduledExpression} from '../utils/schedule-parser.js'
 import {runValidation} from '../utils/validation.js'
@@ -523,4 +526,19 @@ function buildQueueFunctionEvent(event: BlueprintQueueFunctionConfigEvent): Blue
     ...defaultEvent,
     ...userProvidedEvent,
   } as BlueprintQueueFunctionResourceEvent
+}
+
+export function defineWorkflowFunction(functionConfig: BlueprintWorkflowFunctionConfig): BlueprintWorkflowFunctionResource {
+  const {name, event, concurrency, debounce, debounceKey, src} = functionConfig
+  const functionResource: BlueprintWorkflowFunctionResource = {
+    ...defineFunction({...functionConfig, src: src ?? `workflows/${name}`}, {skipValidation: true}),
+    type: 'sanity.function.workflow',
+    ...(event && {event}),
+    ...(concurrency && {concurrency}),
+    ...(debounce && {debounce}),
+    ...(debounceKey && {debounceKey}),
+  }
+
+  runValidation(() => validateWorkflowFunction(functionResource))
+  return functionResource
 }

--- a/src/definers/functions.ts
+++ b/src/definers/functions.ts
@@ -528,15 +528,39 @@ function buildQueueFunctionEvent(event: BlueprintQueueFunctionConfigEvent): Blue
   } as BlueprintQueueFunctionResourceEvent
 }
 
-export function defineWorkflowFunction(functionConfig: BlueprintWorkflowFunctionConfig): BlueprintWorkflowFunctionResource {
+/**
+ * Defines a workflow function resource.
+ *
+ * @remarks
+ *
+ * ```ts
+ * defineWorkflow({
+ *   name: 'daily-cleanup',
+ *   event: {type: 'document', on: ['create'], filter: "_type == 'post'"},
+ *   concurrency: 5,
+ *   debounce: 10,
+ *   debounceKey: 'document._id',
+ * })
+ * ```
+ *
+ *
+ * @param functionConfig The configuration for the function
+ * @category Definers
+ * @alpha Deploying Scheduled Functions via Blueprints is experimental. This feature is not available publicly yet.
+ * @public
+ * @hidden
+ * @expandType BlueprintWorkflowFunctionConfig
+ * @returns The validated workflow function resource
+ */
+export function defineWorkflow(functionConfig: BlueprintWorkflowFunctionConfig): BlueprintWorkflowFunctionResource {
   const {name, event, concurrency, debounce, debounceKey, src} = functionConfig
   const functionResource: BlueprintWorkflowFunctionResource = {
     ...defineFunction({...functionConfig, src: src ?? `workflows/${name}`}, {skipValidation: true}),
     type: 'sanity.function.workflow',
-    ...(event && {event}),
-    ...(concurrency && {concurrency}),
-    ...(debounce && {debounce}),
-    ...(debounceKey && {debounceKey}),
+    event,
+    ...(concurrency !== undefined && {concurrency}),
+    ...(debounce !== undefined && {debounce}),
+    ...(debounceKey !== undefined && {debounceKey}),
   }
 
   runValidation(() => validateWorkflowFunction(functionResource))

--- a/src/definers/functions.ts
+++ b/src/definers/functions.ts
@@ -546,7 +546,7 @@ function buildQueueFunctionEvent(event: BlueprintQueueFunctionConfigEvent): Blue
  *
  * @param functionConfig The configuration for the function
  * @category Definers
- * @alpha Deploying Scheduled Functions via Blueprints is experimental. This feature is not available publicly yet.
+ * @alpha Deploying Workflows via Blueprints is experimental. This feature is not available publicly yet.
  * @public
  * @hidden
  * @expandType BlueprintWorkflowFunctionConfig

--- a/src/types/functions/event.ts
+++ b/src/types/functions/event.ts
@@ -145,3 +145,4 @@ export type BlueprintFunctionResourceEventName = 'publish' | 'create' | 'delete'
 export type BlueprintWorkflowFunctionResourceEvent =
   | ({type: 'document'} & BlueprintDocumentFunctionResourceEvent)
   | ({type: 'sync-tag-invalidate'} & BlueprintSyncTagInvalidateFunctionResourceEvent)
+  | ({type: 'media-library'} & BlueprintMediaLibraryFunctionResourceEvent)

--- a/src/types/functions/index.ts
+++ b/src/types/functions/index.ts
@@ -261,13 +261,15 @@ export type BlueprintEventFunctionConfig = Omit<BlueprintEventFunctionResource, 
  */
 export interface BlueprintWorkflowFunctionResource extends BlueprintBaseFunctionResource {
   type: 'sanity.function.workflow'
-  event: BlueprintWorkflowFunctionResourceEvent
+  event?: BlueprintWorkflowFunctionResourceEvent
   /**
-   * Max concurrent executions
+   * Concurrent executions
+   * Min 1
+   * Max 500
    */
   concurrency?: number
   /**
-   * Debounce window in minutes
+   * Debounce window in seconds
    */
   debounce?: number
   /**
@@ -293,5 +295,5 @@ export type BlueprintWorkflowFunctionConfig = Omit<BlueprintWorkflowFunctionReso
   /**
    * Trigger configuration
    */
-  event: BlueprintWorkflowFunctionResourceEvent
+  event?: BlueprintWorkflowFunctionResourceEvent
 }

--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -514,11 +514,11 @@ function validateWorkflowFunctionEvent(event: unknown): BlueprintError[] {
     return [{type: 'invalid_value', message: '`event.type` must be provided'}]
   }
 
-  const errors: BlueprintError[] = []
-
-  if ('type' in event && event.type !== 'document' && event.type !== 'sync-tag-invalidate') {
-    errors.push({type: 'invalid_value', message: '`event.type` must be either `document` or `sync-tag-invalidate`'})
+  if ('type' in event && event.type !== 'document' && event.type !== 'sync-tag-invalidate' && event.type !== 'media-library') {
+    return [{type: 'invalid_value', message: '`event.type` must be either `document`, `sync-tag-invalidate`, or `media-library`'}]
   }
+
+  const errors: BlueprintError[] = []
 
   switch (event.type) {
     case 'document':
@@ -526,6 +526,9 @@ function validateWorkflowFunctionEvent(event: unknown): BlueprintError[] {
       break
     case 'sync-tag-invalidate':
       errors.push(...validateFunctionEventResourceDataset(event))
+      break
+    case 'media-library':
+      errors.push(...validateMediaLibraryFunctionEvent(event))
       break
   }
 
@@ -566,14 +569,16 @@ export function validateWorkflowFunction(functionResource: unknown): BlueprintEr
     errors.push({type: 'invalid_value', message: '`concurrency` must be at least 1'})
   }
 
+  if ('concurrency' in functionResource && typeof functionResource.concurrency === 'number' && functionResource.concurrency > 500) {
+    errors.push({type: 'invalid_value', message: '`concurrency` must be less than 500'})
+  }
+
   if ('debounce' in functionResource && typeof functionResource.debounce !== 'number') {
     errors.push({type: 'invalid_type', message: '`debounce` must be a number'})
   }
 
   if ('event' in functionResource) {
     errors.push(...validateWorkflowFunctionEvent(functionResource.event))
-  } else {
-    errors.push({type: 'missing_parameter', message: '`event` is required for a workflow'})
   }
 
   errors.push(...validateFunction(functionResource))

--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -439,7 +439,6 @@ export function validateSyncTagInvalidateFunction(functionResource: unknown): Bl
  * @category Functions Types
  * @returns Array of validation errors, empty if valid
  */
-
 export function validateQueueFunction(functionResource: unknown): BlueprintError[] {
   if (!functionResource) return [{type: 'invalid_value', message: 'Function config must be provided'}]
   if (typeof functionResource !== 'object') return [{type: 'invalid_type', message: 'Function config must be an object'}]
@@ -481,7 +480,7 @@ function validateQueueFunctionEvent(event: unknown): BlueprintError[] {
 }
 
 /**
- * Validates a event function resource configuration.
+ * Validates an event function resource configuration.
  * @param functionResource The function resource to validate
  * @alpha
  * @hidden
@@ -497,6 +496,29 @@ export function validateEventFunction(functionResource: unknown): BlueprintError
 
   if ('type' in functionResource && functionResource.type !== 'sanity.function.event') {
     errors.push({type: 'invalid_value', message: '`type` must be `sanity.function.event`'})
+  }
+
+  errors.push(...validateFunction(functionResource))
+
+  return errors
+}
+
+/**
+ * Validates a workflow function resource configuration.
+ * @param functionResource The function resource to validate
+ * @alpha
+ * @hidden
+ * @category Functions Types
+ * @returns Array of validation errors, empty if valid
+ */
+export function validateWorkflowFunction(functionResource: unknown): BlueprintError[] {
+  if (!functionResource) return [{type: 'invalid_value', message: 'Function config must be provided'}]
+  if (typeof functionResource !== 'object') return [{type: 'invalid_type', message: 'Function config must be an object'}]
+
+  const errors: BlueprintError[] = []
+
+  if ('type' in functionResource && functionResource.type !== 'sanity.function.workflow') {
+    errors.push({type: 'invalid_value', message: '`type` must be `sanity.function.workflow`'})
   }
 
   errors.push(...validateFunction(functionResource))

--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -503,6 +503,22 @@ export function validateEventFunction(functionResource: unknown): BlueprintError
   return errors
 }
 
+export function validateWorkflowFunctionEvent(event: unknown): BlueprintError[] {
+  if (!event || typeof event !== 'object') return [{type: 'invalid_type', message: '`event` must be an object'}]
+
+  const errors: BlueprintError[] = []
+
+  if (!('type' in event)) {
+    errors.push({type: 'invalid_value', message: '`event.type` must be provided'})
+  }
+
+  if ('type' in event && event.type !== 'document' && event.type !== 'sync-tag-invalidate') {
+    errors.push({type: 'invalid_value', message: '`event.type` must be either `document` or `sync-tag-invalidate`'})
+  }
+
+  return errors
+}
+
 /**
  * Validates a workflow function resource configuration.
  * @param functionResource The function resource to validate
@@ -519,6 +535,30 @@ export function validateWorkflowFunction(functionResource: unknown): BlueprintEr
 
   if ('type' in functionResource && functionResource.type !== 'sanity.function.workflow') {
     errors.push({type: 'invalid_value', message: '`type` must be `sanity.function.workflow`'})
+  }
+
+  if ('debounceKey' in functionResource && typeof functionResource.debounceKey !== 'string') {
+    errors.push({type: 'invalid_type', message: '`debounceKey` must be a string'})
+  }
+
+  if ('debounceKey' in functionResource && !('debounce' in functionResource)) {
+    errors.push({type: 'invalid_value', message: '`debounceKey` requires a `debounce` to be set'})
+  }
+
+  if ('concurrency' in functionResource && typeof functionResource.concurrency !== 'number') {
+    errors.push({type: 'invalid_type', message: '`concurrency` must be a number'})
+  }
+
+  if ('concurrency' in functionResource && typeof functionResource.concurrency === 'number' && functionResource.concurrency < 1) {
+    errors.push({type: 'invalid_value', message: '`concurrency` must be at least 1'})
+  }
+
+  if ('debounce' in functionResource && typeof functionResource.debounce !== 'number') {
+    errors.push({type: 'invalid_type', message: '`debounce` must be a number'})
+  }
+
+  if ('event' in functionResource) {
+    errors.push(...validateWorkflowFunctionEvent(functionResource.event))
   }
 
   errors.push(...validateFunction(functionResource))

--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -505,15 +505,23 @@ export function validateEventFunction(functionResource: unknown): BlueprintError
 
 export function validateWorkflowFunctionEvent(event: unknown): BlueprintError[] {
   if (!event || typeof event !== 'object') return [{type: 'invalid_type', message: '`event` must be an object'}]
+  if (!('type' in event)) {
+    return [{type: 'invalid_value', message: '`event.type` must be provided'}]
+  }
 
   const errors: BlueprintError[] = []
 
-  if (!('type' in event)) {
-    errors.push({type: 'invalid_value', message: '`event.type` must be provided'})
-  }
-
   if ('type' in event && event.type !== 'document' && event.type !== 'sync-tag-invalidate') {
     errors.push({type: 'invalid_value', message: '`event.type` must be either `document` or `sync-tag-invalidate`'})
+  }
+
+  switch (event.type) {
+    case 'document':
+      errors.push(...validateDocumentFunctionEvent(event))
+      break
+    case 'sync-tag-invalidate':
+      errors.push(...validateFunctionEventResourceDataset(event))
+      break
   }
 
   return errors
@@ -559,6 +567,8 @@ export function validateWorkflowFunction(functionResource: unknown): BlueprintEr
 
   if ('event' in functionResource) {
     errors.push(...validateWorkflowFunctionEvent(functionResource.event))
+  } else {
+    errors.push({type: 'missing_parameter', message: '`event` is required for a workflow'})
   }
 
   errors.push(...validateFunction(functionResource))

--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -503,7 +503,12 @@ export function validateEventFunction(functionResource: unknown): BlueprintError
   return errors
 }
 
-export function validateWorkflowFunctionEvent(event: unknown): BlueprintError[] {
+/**
+ * Validates a workflow function event configuration.
+ * @param event The event configuration to validate
+ * @returns Array of validation errors, empty if valid
+ */
+function validateWorkflowFunctionEvent(event: unknown): BlueprintError[] {
   if (!event || typeof event !== 'object') return [{type: 'invalid_type', message: '`event` must be an object'}]
   if (!('type' in event)) {
     return [{type: 'invalid_value', message: '`event.type` must be provided'}]

--- a/test/unit/definers/functions.test.ts
+++ b/test/unit/definers/functions.test.ts
@@ -301,10 +301,10 @@ describe('defineScheduledFunction', () => {
   })
 })
 
-describe('defineWorkflowFunction', () => {
+describe('defineWorkflow', () => {
   describe('happy paths', () => {
     test('should create a workflow event', () => {
-      const fn = fns.defineWorkflowFunction({
+      const fn = fns.defineWorkflow({
         name: 'test',
         event: {type: 'document', on: ['create'], filter: "_type == 'article'"},
       })
@@ -312,7 +312,7 @@ describe('defineWorkflowFunction', () => {
     })
 
     test('should create a workflow function with optional concurrency', () => {
-      const fn = fns.defineWorkflowFunction({
+      const fn = fns.defineWorkflow({
         name: 'test',
         concurrency: 3,
         event: {type: 'document', on: ['create'], filter: "_type == 'article'"},
@@ -322,7 +322,7 @@ describe('defineWorkflowFunction', () => {
     })
 
     test('should create a workflow function with optional debounce', () => {
-      const fn = fns.defineWorkflowFunction({
+      const fn = fns.defineWorkflow({
         name: 'test',
         debounce: 3,
         event: {type: 'document', on: ['create'], filter: "_type == 'article'"},
@@ -332,7 +332,7 @@ describe('defineWorkflowFunction', () => {
     })
 
     test('should create a workflow function with optional debounceKey', () => {
-      const fn = fns.defineWorkflowFunction({
+      const fn = fns.defineWorkflow({
         name: 'test',
         debounceKey: 'testKey',
         event: {type: 'document', on: ['create'], filter: "_type == 'article'"},
@@ -351,7 +351,7 @@ describe('defineWorkflowFunction', () => {
       const spy = vi.spyOn(index, 'validateWorkflowFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
       expect(() =>
         defineBlueprintForResource(
-          fns.defineWorkflowFunction({name: 'test', event: {type: 'document', on: ['create'], filter: "_type == 'article'"}}),
+          fns.defineWorkflow({name: 'test', event: {type: 'document', on: ['create'], filter: "_type == 'article'"}}),
         ),
       ).toThrow('this is a test')
 

--- a/test/unit/definers/functions.test.ts
+++ b/test/unit/definers/functions.test.ts
@@ -306,6 +306,13 @@ describe('defineWorkflow', () => {
     test('should create a workflow event', () => {
       const fn = fns.defineWorkflow({
         name: 'test',
+      })
+      expect(fn.name).toEqual('test')
+    })
+
+    test('should create a workflow with an event', () => {
+      const fn = fns.defineWorkflow({
+        name: 'test',
         event: {type: 'document', on: ['create'], filter: "_type == 'article'"},
       })
       expect(fn.event).toEqual({type: 'document', on: ['create'], filter: "_type == 'article'"})
@@ -315,30 +322,29 @@ describe('defineWorkflow', () => {
       const fn = fns.defineWorkflow({
         name: 'test',
         concurrency: 3,
-        event: {type: 'document', on: ['create'], filter: "_type == 'article'"},
       })
       expect(fn.concurrency).toEqual(3)
-      expect(fn.event).toEqual({type: 'document', on: ['create'], filter: "_type == 'article'"})
+      expect(fn.name).toEqual('test')
     })
 
     test('should create a workflow function with optional debounce', () => {
       const fn = fns.defineWorkflow({
         name: 'test',
         debounce: 3,
-        event: {type: 'document', on: ['create'], filter: "_type == 'article'"},
       })
       expect(fn.debounce).toEqual(3)
-      expect(fn.event).toEqual({type: 'document', on: ['create'], filter: "_type == 'article'"})
+      expect(fn.name).toEqual('test')
     })
 
     test('should create a workflow function with optional debounceKey', () => {
       const fn = fns.defineWorkflow({
         name: 'test',
+        debounce: 1,
         debounceKey: 'testKey',
-        event: {type: 'document', on: ['create'], filter: "_type == 'article'"},
       })
+      expect(fn.debounce).toEqual(1)
       expect(fn.debounceKey).toEqual('testKey')
-      expect(fn.event).toEqual({type: 'document', on: ['create'], filter: "_type == 'article'"})
+      expect(fn.name).toEqual('test')
     })
   })
 

--- a/test/unit/definers/functions.test.ts
+++ b/test/unit/definers/functions.test.ts
@@ -300,3 +300,62 @@ describe('defineScheduledFunction', () => {
     })
   })
 })
+
+describe('defineWorkflowFunction', () => {
+  describe('happy paths', () => {
+    test('should create a workflow event', () => {
+      const fn = fns.defineWorkflowFunction({
+        name: 'test',
+        event: {type: 'document', on: ['create'], filter: "_type == 'article'"},
+      })
+      expect(fn.event).toEqual({type: 'document', on: ['create'], filter: "_type == 'article'"})
+    })
+
+    test('should create a workflow function with optional concurrency', () => {
+      const fn = fns.defineWorkflowFunction({
+        name: 'test',
+        concurrency: 3,
+        event: {type: 'document', on: ['create'], filter: "_type == 'article'"},
+      })
+      expect(fn.concurrency).toEqual(3)
+      expect(fn.event).toEqual({type: 'document', on: ['create'], filter: "_type == 'article'"})
+    })
+
+    test('should create a workflow function with optional debounce', () => {
+      const fn = fns.defineWorkflowFunction({
+        name: 'test',
+        debounce: 3,
+        event: {type: 'document', on: ['create'], filter: "_type == 'article'"},
+      })
+      expect(fn.debounce).toEqual(3)
+      expect(fn.event).toEqual({type: 'document', on: ['create'], filter: "_type == 'article'"})
+    })
+
+    test('should create a workflow function with optional debounceKey', () => {
+      const fn = fns.defineWorkflowFunction({
+        name: 'test',
+        debounceKey: 'testKey',
+        event: {type: 'document', on: ['create'], filter: "_type == 'article'"},
+      })
+      expect(fn.debounceKey).toEqual('testKey')
+      expect(fn.event).toEqual({type: 'document', on: ['create'], filter: "_type == 'article'"})
+    })
+  })
+
+  describe('sad paths', () => {
+    afterEach(() => {
+      vi.resetAllMocks()
+    })
+
+    test('should throw an error if validateWorkflowFunction returns an error', () => {
+      const spy = vi.spyOn(index, 'validateWorkflowFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
+      expect(() =>
+        defineBlueprintForResource(
+          fns.defineWorkflowFunction({name: 'test', event: {type: 'document', on: ['create'], filter: "_type == 'article'"}}),
+        ),
+      ).toThrow('this is a test')
+
+      expect(spy).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -886,45 +886,45 @@ describe('validateWorkflowFunction', () => {
         message: '`concurrency` must be at least 1',
       })
     })
-  })
 
-  test('should return an error if debounce is not a number', () => {
-    const errors = functions.validateWorkflowFunction({
-      name: 'test',
-      type: 'sanity.function.workflow',
-      event: {type: 'document', filter: "_type == 'article'"},
-      debounce: 'invalid',
+    test('should return an error if debounce is not a number', () => {
+      const errors = functions.validateWorkflowFunction({
+        name: 'test',
+        type: 'sanity.function.workflow',
+        event: {type: 'document', filter: "_type == 'article'"},
+        debounce: 'invalid',
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_type',
+        message: '`debounce` must be a number',
+      })
     })
-    expect(errors).toContainEqual({
-      type: 'invalid_type',
-      message: '`debounce` must be a number',
-    })
-  })
 
-  test('should return an error if debounceKey is set and not a string', () => {
-    const errors = functions.validateWorkflowFunction({
-      name: 'test',
-      type: 'sanity.function.workflow',
-      event: {type: 'document', filter: "_type == 'article'"},
-      debounce: 1,
-      debounceKey: 123,
+    test('should return an error if debounceKey is set and not a string', () => {
+      const errors = functions.validateWorkflowFunction({
+        name: 'test',
+        type: 'sanity.function.workflow',
+        event: {type: 'document', filter: "_type == 'article'"},
+        debounce: 1,
+        debounceKey: 123,
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_type',
+        message: '`debounceKey` must be a string',
+      })
     })
-    expect(errors).toContainEqual({
-      type: 'invalid_type',
-      message: '`debounceKey` must be a string',
-    })
-  })
 
-  test('should return an error if debounceKey is set but debounce is empty', () => {
-    const errors = functions.validateWorkflowFunction({
-      name: 'test',
-      type: 'sanity.function.workflow',
-      event: {type: 'document', filter: "_type == 'article'"},
-      debounceKey: '_document.id',
-    })
-    expect(errors).toContainEqual({
-      type: 'invalid_value',
-      message: '`debounceKey` requires a `debounce` to be set',
+    test('should return an error if debounceKey is set but debounce is empty', () => {
+      const errors = functions.validateWorkflowFunction({
+        name: 'test',
+        type: 'sanity.function.workflow',
+        event: {type: 'document', filter: "_type == 'article'"},
+        debounceKey: '_document.id',
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_value',
+        message: '`debounceKey` requires a `debounce` to be set',
+      })
     })
   })
 })

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -828,3 +828,24 @@ describe('validateEventFunction', () => {
     })
   })
 })
+
+describe('validateWorkflowFunction', () => {
+  describe('happy paths', () => {
+    test('should accept a valid workflow function without any optional properties', () => {
+      const errors = functions.validateWorkflowFunction({
+        name: 'test',
+        type: 'sanity.function.workflow',
+      })
+      expect(errors).toStrictEqual([])
+    })
+  })
+  describe('sad paths', () => {
+    test('should return an error if the type is not `sanity.function.workflow`', () => {
+      const errors = functions.validateWorkflowFunction({type: 'invalid'})
+      expect(errors).toContainEqual({
+        type: 'invalid_value',
+        message: '`type` must be `sanity.function.workflow`',
+      })
+    })
+  })
+})

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -835,6 +835,7 @@ describe('validateWorkflowFunction', () => {
       const errors = functions.validateWorkflowFunction({
         name: 'test',
         type: 'sanity.function.workflow',
+        event: {type: 'document', filter: "_type == 'article'"},
       })
       expect(errors).toStrictEqual([])
     })
@@ -846,6 +847,84 @@ describe('validateWorkflowFunction', () => {
         type: 'invalid_value',
         message: '`type` must be `sanity.function.workflow`',
       })
+    })
+
+    test('should return an error if the event type is invalid', () => {
+      const errors = functions.validateWorkflowFunction({
+        name: 'test',
+        type: 'sanity.function.workflow',
+        event: {type: 'invalid', filter: "_type == 'article'"},
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_value',
+        message: '`event.type` must be either `document` or `sync-tag-invalidate`',
+      })
+    })
+
+    test('should return an error if concurrency is not a number', () => {
+      const errors = functions.validateWorkflowFunction({
+        name: 'test',
+        type: 'sanity.function.workflow',
+        event: {type: 'document', filter: "_type == 'article'"},
+        concurrency: 'invalid',
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_type',
+        message: '`concurrency` must be a number',
+      })
+    })
+
+    test('should return an error if concurrency is less than 1', () => {
+      const errors = functions.validateWorkflowFunction({
+        name: 'test',
+        type: 'sanity.function.workflow',
+        event: {type: 'document', filter: "_type == 'article'"},
+        concurrency: 0,
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_value',
+        message: '`concurrency` must be at least 1',
+      })
+    })
+  })
+
+  test('should return an error if debounce is not a number', () => {
+    const errors = functions.validateWorkflowFunction({
+      name: 'test',
+      type: 'sanity.function.workflow',
+      event: {type: 'document', filter: "_type == 'article'"},
+      debounce: 'invalid',
+    })
+    expect(errors).toContainEqual({
+      type: 'invalid_type',
+      message: '`debounce` must be a number',
+    })
+  })
+
+  test('should return an error if debounceKey is set and not a string', () => {
+    const errors = functions.validateWorkflowFunction({
+      name: 'test',
+      type: 'sanity.function.workflow',
+      event: {type: 'document', filter: "_type == 'article'"},
+      debounce: 1,
+      debounceKey: 123,
+    })
+    expect(errors).toContainEqual({
+      type: 'invalid_type',
+      message: '`debounceKey` must be a string',
+    })
+  })
+
+  test('should return an error if debounceKey is set but debounce is empty', () => {
+    const errors = functions.validateWorkflowFunction({
+      name: 'test',
+      type: 'sanity.function.workflow',
+      event: {type: 'document', filter: "_type == 'article'"},
+      debounceKey: '_document.id',
+    })
+    expect(errors).toContainEqual({
+      type: 'invalid_value',
+      message: '`debounceKey` requires a `debounce` to be set',
     })
   })
 })

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -840,6 +840,7 @@ describe('validateWorkflowFunction', () => {
       expect(errors).toStrictEqual([])
     })
   })
+
   describe('sad paths', () => {
     test('should return an error if the type is not `sanity.function.workflow`', () => {
       const errors = functions.validateWorkflowFunction({type: 'invalid'})
@@ -857,7 +858,7 @@ describe('validateWorkflowFunction', () => {
       })
       expect(errors).toContainEqual({
         type: 'invalid_value',
-        message: '`event.type` must be either `document` or `sync-tag-invalidate`',
+        message: '`event.type` must be either `document`, `sync-tag-invalidate`, or `media-library`',
       })
     })
 
@@ -865,7 +866,6 @@ describe('validateWorkflowFunction', () => {
       const errors = functions.validateWorkflowFunction({
         name: 'test',
         type: 'sanity.function.workflow',
-        event: {type: 'document', filter: "_type == 'article'"},
         concurrency: 'invalid',
       })
       expect(errors).toContainEqual({
@@ -878,12 +878,23 @@ describe('validateWorkflowFunction', () => {
       const errors = functions.validateWorkflowFunction({
         name: 'test',
         type: 'sanity.function.workflow',
-        event: {type: 'document', filter: "_type == 'article'"},
         concurrency: 0,
       })
       expect(errors).toContainEqual({
         type: 'invalid_value',
         message: '`concurrency` must be at least 1',
+      })
+    })
+
+    test('should return an error if concurrency is greater than 500', () => {
+      const errors = functions.validateWorkflowFunction({
+        name: 'test',
+        type: 'sanity.function.workflow',
+        concurrency: 600,
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_value',
+        message: '`concurrency` must be less than 500',
       })
     })
 


### PR DESCRIPTION
### Description
Adding `defineWorkflow` definer.  Simple example in the README and validation.

### What to review
Im basing the validation on the event type being one of 'document' and 'sync-tag-invalidate'. There could be other `types` we want to distinguish on though. As of now, everything is really just thinking about the most basic example and iterating on that. The other thought which might warrant a little extra thought is the `event` needing to be extracted during the deploy phase to match this example. `event` is currently required, but maybe needs to be loosened so it can be properly extracted and added during the `blueprints deploy` . 

```
export default defineBlueprint({
  resources: [
    defineWorkflow({
      name: 'my-workflow',
    }),
  ],
})

```

```
import { workflow } from '@sanity/blueprints'
import shopify from 'shopify'

const syncToShopify = workflow.createFunction(
  {
    name: 'sync-to-shopify',
    event: {
      type: 'document', // Needed to differentiate document vs. sync tag invalidate events
      on: ['create', 'update'],
      filter: '_type == "product"'
    },
    concurrency: 1, // Respect conservative rate limits
    debounce: 2, // Expressed in seconds
    debounceKey: 'document._id',
  },
  async ({ event, step }) => {
    const product = await step.run('load-product', async () => {
      return shopify.loadProduct(event.document._id)
    })

    await step.run('push-to-shopify', async () => {
      return shopify.updateProduct(product)
    })
  },
)

```


### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
