### PR TITLE
Define queue

### DIFF
--- a/src/definers/functions.ts
+++ b/src/definers/functions.ts
@@ -359,7 +359,7 @@ export function defineSyncTagInvalidateFunction(
  * @returns The validated queue function resource
  */
 export function defineQueueFunction(functionConfig: BlueprintQueueFunctionConfig): BlueprintQueueFunctionResource {
-  const { concurrency, fifo, dlq } = functionConfig
+  const { concurrency, fifo, dlq, event } = functionConfig
 
   const functionResource: BlueprintQueueFunctionResource = {
     ...defineFunction(functionConfig, { skipValidation: true }),
@@ -367,6 +367,7 @@ export function defineQueueFunction(functionConfig: BlueprintQueueFunctionConfig
     ...(concurrency !== undefined && { concurrency }),
     ...(fifo !== undefined && { fifo }),
     ...(dlq !== undefined && { dlq }),
+    ...(event !== undefined && { event }),
   }
 
   runValidation(() => validateQueueFunction(functionResource))

--- a/src/definers/functions.ts
+++ b/src/definers/functions.ts
@@ -357,7 +357,7 @@ export function defineSyncTagInvalidateFunction(
  * @returns The validated queue function resource
  */
 export function defineQueueFunction(functionConfig: BlueprintQueueFunctionConfig): BlueprintQueueFunctionResource {
-  const {concurrency, fifo, dlq, event} = functionConfig
+  const {concurrency = 1, fifo = true, dlq = true, event} = functionConfig
 
   const functionResource: BlueprintQueueFunctionResource = {
     ...defineFunction(functionConfig, {skipValidation: true}),
@@ -529,7 +529,7 @@ export function defineWorkflow(functionConfig: BlueprintWorkflowFunctionConfig):
   const functionResource: BlueprintWorkflowFunctionResource = {
     ...defineFunction({...functionConfig, src: src ?? `workflows/${name}`}, {skipValidation: true}),
     type: 'sanity.function.workflow',
-    event,
+    ...(event !== undefined && {event}),
     ...(concurrency !== undefined && {concurrency}),
     ...(debounce !== undefined && {debounce}),
     ...(debounceKey !== undefined && {debounceKey}),

--- a/src/definers/functions.ts
+++ b/src/definers/functions.ts
@@ -44,8 +44,6 @@ type ScheduledFunctionEventKey =
   | keyof BlueprintScheduledFunctionExplicitResourceEvent
   | keyof BlueprintScheduledFunctionExpressionResourceEvent
 const SCHEDULED_EVENT_KEYS = new Set<ScheduledFunctionEventKey>(['minute', 'hour', 'dayOfWeek', 'month', 'dayOfMonth', 'expression'])
-// type QueueFunctionEventKey = keyof BlueprintQueueFunctionResourceEvent
-// const QUEUE_EVENT_KEYS = new Set<QueueFunctionEventKey>(['concurrency', 'fifo', 'dlq'])
 
 /*
  * FUTURE example (move below @example when ready)
@@ -501,23 +499,6 @@ function cronStringToExplicitEvent(cron: string): BlueprintScheduledFunctionExpl
   const [minute, hour, dayOfMonth, month, dayOfWeek] = parts
   return {minute, hour, dayOfMonth, month, dayOfWeek}
 }
-
-/**
- * Builds a queue function event configuration.
- * @param event Queue function event configuration
- * @returns Cleaned queue function event configuration
-function buildQueueFunctionEvent(event: BlueprintQueueFunctionConfigEvent): BlueprintQueueFunctionResourceEvent {
-  const defaultEvent = { concurrency: 1, fifo: true, dlq: true }
-  if (typeof event === 'boolean') {
-    return defaultEvent
-  }
-  const userProvidedEvent = Object.fromEntries(Object.entries(event).filter(([key]) => QUEUE_EVENT_KEYS.has(key as QueueFunctionEventKey)))
-  return {
-    ...defaultEvent,
-    ...userProvidedEvent,
-  } as BlueprintQueueFunctionResourceEvent
-}
-*/
 
 /**
  * Defines a workflow function resource.

--- a/src/definers/functions.ts
+++ b/src/definers/functions.ts
@@ -31,8 +31,8 @@ import {
   validateSyncTagInvalidateFunction,
   validateWorkflowFunction,
 } from '../index.js'
-import { parseScheduledExpression } from '../utils/schedule-parser.js'
-import { runValidation } from '../utils/validation.js'
+import {parseScheduledExpression} from '../utils/schedule-parser.js'
+import {runValidation} from '../utils/validation.js'
 
 type BaseFunctionEventKey = keyof BlueprintFunctionBaseResourceEvent
 const BASE_EVENT_KEYS = new Set<BaseFunctionEventKey>(['on', 'filter', 'projection', 'includeDrafts'])
@@ -115,7 +115,7 @@ export function defineDocumentFunction(
 export function defineDocumentFunction(
   functionConfig: BlueprintDocumentFunctionConfig & Partial<BlueprintDocumentFunctionResourceEvent>,
 ): BlueprintDocumentFunctionResource {
-  let { name, src, event, timeout, memory, env, robotToken, project, runtime, ...maybeEvent } = functionConfig
+  let {name, src, event, timeout, memory, env, robotToken, project, runtime, ...maybeEvent} = functionConfig
 
   // event validation and normalization
   if (event) {
@@ -137,7 +137,7 @@ export function defineDocumentFunction(
   }
 
   const functionResource: BlueprintDocumentFunctionResource = {
-    ...defineFunction(functionConfig, { skipValidation: true }),
+    ...defineFunction(functionConfig, {skipValidation: true}),
     type: 'sanity.function.document',
     event,
   }
@@ -203,10 +203,10 @@ export function defineDocumentFunction(
 export function defineMediaLibraryAssetFunction(
   functionConfig: BlueprintMediaLibraryAssetFunctionConfig,
 ): BlueprintMediaLibraryAssetFunctionResource {
-  const { event } = functionConfig
+  const {event} = functionConfig
 
   const functionResource: BlueprintMediaLibraryAssetFunctionResource = {
-    ...defineFunction(functionConfig, { skipValidation: true }),
+    ...defineFunction(functionConfig, {skipValidation: true}),
     type: 'sanity.function.media-library.asset',
     event: buildMediaLibraryFunctionEvent(event),
   }
@@ -256,10 +256,10 @@ export function defineMediaLibraryAssetFunction(
  * @returns The validated scheduled function resource
  */
 export function defineScheduledFunction(functionConfig: BlueprintScheduledFunctionConfig): BlueprintScheduledFunctionResource {
-  const { event, timezone } = functionConfig
+  const {event, timezone} = functionConfig
 
   const functionResource: BlueprintScheduledFunctionResource = {
-    ...defineFunction(functionConfig, { skipValidation: true, scopeType: 'organization' }),
+    ...defineFunction(functionConfig, {skipValidation: true, scopeType: 'organization'}),
     type: 'sanity.function.cron',
     event: buildScheduledFunctionEvent(event),
   }
@@ -317,12 +317,12 @@ export function defineScheduleFunction(functionConfig: BlueprintScheduledFunctio
 export function defineSyncTagInvalidateFunction(
   functionConfig: BlueprintSyncTagInvalidateFunctionConfig,
 ): BlueprintSyncTagInvalidateFunctionResource {
-  const { event } = functionConfig
+  const {event} = functionConfig
 
   const functionResource: BlueprintSyncTagInvalidateFunctionResource = {
-    ...defineFunction(functionConfig, { skipValidation: true }),
+    ...defineFunction(functionConfig, {skipValidation: true}),
     type: 'sanity.function.sync-tag-invalidate',
-    ...(event?.resource ? { event } : {}),
+    ...(event?.resource ? {event} : {}),
   }
 
   runValidation(() => validateSyncTagInvalidateFunction(functionResource))
@@ -359,15 +359,15 @@ export function defineSyncTagInvalidateFunction(
  * @returns The validated queue function resource
  */
 export function defineQueueFunction(functionConfig: BlueprintQueueFunctionConfig): BlueprintQueueFunctionResource {
-  const { concurrency, fifo, dlq, event } = functionConfig
+  const {concurrency, fifo, dlq, event} = functionConfig
 
   const functionResource: BlueprintQueueFunctionResource = {
-    ...defineFunction(functionConfig, { skipValidation: true }),
+    ...defineFunction(functionConfig, {skipValidation: true}),
     type: 'sanity.function.queue',
-    ...(concurrency !== undefined && { concurrency }),
-    ...(fifo !== undefined && { fifo }),
-    ...(dlq !== undefined && { dlq }),
-    ...(event !== undefined && { event }),
+    ...(concurrency !== undefined && {concurrency}),
+    ...(fifo !== undefined && {fifo}),
+    ...(dlq !== undefined && {dlq}),
+    ...(event !== undefined && {event}),
   }
 
   runValidation(() => validateQueueFunction(functionResource))
@@ -395,7 +395,7 @@ export function defineQueueFunction(functionConfig: BlueprintQueueFunctionConfig
  */
 export function defineEventFunction(functionConfig: BlueprintEventFunctionConfig): BlueprintEventFunctionResource {
   const functionResource: BlueprintEventFunctionResource = {
-    ...defineFunction(functionConfig, { skipValidation: true }),
+    ...defineFunction(functionConfig, {skipValidation: true}),
     type: 'sanity.function.event',
   }
 
@@ -416,9 +416,9 @@ export function defineEventFunction(functionConfig: BlueprintEventFunctionConfig
  */
 export function defineFunction(
   functionConfig: BlueprintBaseFunctionConfig,
-  options?: { skipValidation?: boolean; scopeType?: 'organization' },
+  options?: {skipValidation?: boolean; scopeType?: 'organization'},
 ): BlueprintBaseFunctionResource {
-  const { name, displayName, src, timeout, memory, env, robotToken, project, runtime, lifecycle } = functionConfig
+  const {name, displayName, src, timeout, memory, env, robotToken, project, runtime, lifecycle} = functionConfig
 
   const functionResource: BlueprintBaseFunctionResource = {
     type: 'sanity.function.document',
@@ -499,7 +499,7 @@ function cronStringToExplicitEvent(cron: string): BlueprintScheduledFunctionExpl
     throw new Error(`Invalid cron string: expected 5 fields, got ${parts.length}`)
   }
   const [minute, hour, dayOfMonth, month, dayOfWeek] = parts
-  return { minute, hour, dayOfMonth, month, dayOfWeek }
+  return {minute, hour, dayOfMonth, month, dayOfWeek}
 }
 
 /**
@@ -544,14 +544,14 @@ function buildQueueFunctionEvent(event: BlueprintQueueFunctionConfigEvent): Blue
  * @returns The validated workflow function resource
  */
 export function defineWorkflow(functionConfig: BlueprintWorkflowFunctionConfig): BlueprintWorkflowFunctionResource {
-  const { name, event, concurrency, debounce, debounceKey, src } = functionConfig
+  const {name, event, concurrency, debounce, debounceKey, src} = functionConfig
   const functionResource: BlueprintWorkflowFunctionResource = {
-    ...defineFunction({ ...functionConfig, src: src ?? `workflows/${name}` }, { skipValidation: true }),
+    ...defineFunction({...functionConfig, src: src ?? `workflows/${name}`}, {skipValidation: true}),
     type: 'sanity.function.workflow',
     event,
-    ...(concurrency !== undefined && { concurrency }),
-    ...(debounce !== undefined && { debounce }),
-    ...(debounceKey !== undefined && { debounceKey }),
+    ...(concurrency !== undefined && {concurrency}),
+    ...(debounce !== undefined && {debounce}),
+    ...(debounceKey !== undefined && {debounceKey}),
   }
 
   runValidation(() => validateWorkflowFunction(functionResource))

--- a/src/definers/functions.ts
+++ b/src/definers/functions.ts
@@ -11,9 +11,7 @@ import {
   type BlueprintMediaLibraryAssetFunctionResource,
   type BlueprintMediaLibraryFunctionResourceEvent,
   type BlueprintQueueFunctionConfig,
-  type BlueprintQueueFunctionConfigEvent,
   type BlueprintQueueFunctionResource,
-  type BlueprintQueueFunctionResourceEvent,
   type BlueprintScheduledFunctionConfig,
   type BlueprintScheduledFunctionConfigEvent,
   type BlueprintScheduledFunctionExplicitResourceEvent,
@@ -33,8 +31,8 @@ import {
   validateSyncTagInvalidateFunction,
   validateWorkflowFunction,
 } from '../index.js'
-import {parseScheduledExpression} from '../utils/schedule-parser.js'
-import {runValidation} from '../utils/validation.js'
+import { parseScheduledExpression } from '../utils/schedule-parser.js'
+import { runValidation } from '../utils/validation.js'
 
 type BaseFunctionEventKey = keyof BlueprintFunctionBaseResourceEvent
 const BASE_EVENT_KEYS = new Set<BaseFunctionEventKey>(['on', 'filter', 'projection', 'includeDrafts'])
@@ -46,8 +44,8 @@ type ScheduledFunctionEventKey =
   | keyof BlueprintScheduledFunctionExplicitResourceEvent
   | keyof BlueprintScheduledFunctionExpressionResourceEvent
 const SCHEDULED_EVENT_KEYS = new Set<ScheduledFunctionEventKey>(['minute', 'hour', 'dayOfWeek', 'month', 'dayOfMonth', 'expression'])
-type QueueFunctionEventKey = keyof BlueprintQueueFunctionResourceEvent
-const QUEUE_EVENT_KEYS = new Set<QueueFunctionEventKey>(['concurrency', 'fifo', 'dlq'])
+// type QueueFunctionEventKey = keyof BlueprintQueueFunctionResourceEvent
+// const QUEUE_EVENT_KEYS = new Set<QueueFunctionEventKey>(['concurrency', 'fifo', 'dlq'])
 
 /*
  * FUTURE example (move below @example when ready)
@@ -117,7 +115,7 @@ export function defineDocumentFunction(
 export function defineDocumentFunction(
   functionConfig: BlueprintDocumentFunctionConfig & Partial<BlueprintDocumentFunctionResourceEvent>,
 ): BlueprintDocumentFunctionResource {
-  let {name, src, event, timeout, memory, env, robotToken, project, runtime, ...maybeEvent} = functionConfig
+  let { name, src, event, timeout, memory, env, robotToken, project, runtime, ...maybeEvent } = functionConfig
 
   // event validation and normalization
   if (event) {
@@ -139,7 +137,7 @@ export function defineDocumentFunction(
   }
 
   const functionResource: BlueprintDocumentFunctionResource = {
-    ...defineFunction(functionConfig, {skipValidation: true}),
+    ...defineFunction(functionConfig, { skipValidation: true }),
     type: 'sanity.function.document',
     event,
   }
@@ -205,10 +203,10 @@ export function defineDocumentFunction(
 export function defineMediaLibraryAssetFunction(
   functionConfig: BlueprintMediaLibraryAssetFunctionConfig,
 ): BlueprintMediaLibraryAssetFunctionResource {
-  const {event} = functionConfig
+  const { event } = functionConfig
 
   const functionResource: BlueprintMediaLibraryAssetFunctionResource = {
-    ...defineFunction(functionConfig, {skipValidation: true}),
+    ...defineFunction(functionConfig, { skipValidation: true }),
     type: 'sanity.function.media-library.asset',
     event: buildMediaLibraryFunctionEvent(event),
   }
@@ -258,10 +256,10 @@ export function defineMediaLibraryAssetFunction(
  * @returns The validated scheduled function resource
  */
 export function defineScheduledFunction(functionConfig: BlueprintScheduledFunctionConfig): BlueprintScheduledFunctionResource {
-  const {event, timezone} = functionConfig
+  const { event, timezone } = functionConfig
 
   const functionResource: BlueprintScheduledFunctionResource = {
-    ...defineFunction(functionConfig, {skipValidation: true, scopeType: 'organization'}),
+    ...defineFunction(functionConfig, { skipValidation: true, scopeType: 'organization' }),
     type: 'sanity.function.cron',
     event: buildScheduledFunctionEvent(event),
   }
@@ -319,12 +317,12 @@ export function defineScheduleFunction(functionConfig: BlueprintScheduledFunctio
 export function defineSyncTagInvalidateFunction(
   functionConfig: BlueprintSyncTagInvalidateFunctionConfig,
 ): BlueprintSyncTagInvalidateFunctionResource {
-  const {event} = functionConfig
+  const { event } = functionConfig
 
   const functionResource: BlueprintSyncTagInvalidateFunctionResource = {
-    ...defineFunction(functionConfig, {skipValidation: true}),
+    ...defineFunction(functionConfig, { skipValidation: true }),
     type: 'sanity.function.sync-tag-invalidate',
-    ...(event?.resource ? {event} : {}),
+    ...(event?.resource ? { event } : {}),
   }
 
   runValidation(() => validateSyncTagInvalidateFunction(functionResource))
@@ -343,23 +341,13 @@ export function defineSyncTagInvalidateFunction(
  * })
  * ```
  *
- * Using the reasonable defaults of concurrency: 1, fifo: true, and dlq: true
- * ```ts
- * defineQueueFunction({
- *   name: 'bustin-caches',
- *   queue: true,
- * })
- * ```
- *
  * Specifying a concurrency of 5
  * ```ts
  * defineQueueFunction({
  *   name: 'bustin-caches',
- *   queue: {
- *    concurrency: 5,
- *    fifo: true,
- *    dlq: true,
- *  },
+ *   concurrency: 5,
+ *   fifo: true,
+ *   dlq: true,
  * })
  * ```
  * @public
@@ -371,12 +359,14 @@ export function defineSyncTagInvalidateFunction(
  * @returns The validated queue function resource
  */
 export function defineQueueFunction(functionConfig: BlueprintQueueFunctionConfig): BlueprintQueueFunctionResource {
-  const {queue = true} = functionConfig
+  const { concurrency, fifo, dlq } = functionConfig
 
   const functionResource: BlueprintQueueFunctionResource = {
-    ...defineFunction(functionConfig, {skipValidation: true}),
+    ...defineFunction(functionConfig, { skipValidation: true }),
     type: 'sanity.function.queue',
-    event: buildQueueFunctionEvent(queue),
+    ...(concurrency !== undefined && { concurrency }),
+    ...(fifo !== undefined && { fifo }),
+    ...(dlq !== undefined && { dlq }),
   }
 
   runValidation(() => validateQueueFunction(functionResource))
@@ -404,7 +394,7 @@ export function defineQueueFunction(functionConfig: BlueprintQueueFunctionConfig
  */
 export function defineEventFunction(functionConfig: BlueprintEventFunctionConfig): BlueprintEventFunctionResource {
   const functionResource: BlueprintEventFunctionResource = {
-    ...defineFunction(functionConfig, {skipValidation: true}),
+    ...defineFunction(functionConfig, { skipValidation: true }),
     type: 'sanity.function.event',
   }
 
@@ -425,9 +415,9 @@ export function defineEventFunction(functionConfig: BlueprintEventFunctionConfig
  */
 export function defineFunction(
   functionConfig: BlueprintBaseFunctionConfig,
-  options?: {skipValidation?: boolean; scopeType?: 'organization'},
+  options?: { skipValidation?: boolean; scopeType?: 'organization' },
 ): BlueprintBaseFunctionResource {
-  const {name, displayName, src, timeout, memory, env, robotToken, project, runtime, lifecycle} = functionConfig
+  const { name, displayName, src, timeout, memory, env, robotToken, project, runtime, lifecycle } = functionConfig
 
   const functionResource: BlueprintBaseFunctionResource = {
     type: 'sanity.function.document',
@@ -508,16 +498,15 @@ function cronStringToExplicitEvent(cron: string): BlueprintScheduledFunctionExpl
     throw new Error(`Invalid cron string: expected 5 fields, got ${parts.length}`)
   }
   const [minute, hour, dayOfMonth, month, dayOfWeek] = parts
-  return {minute, hour, dayOfMonth, month, dayOfWeek}
+  return { minute, hour, dayOfMonth, month, dayOfWeek }
 }
 
 /**
  * Builds a queue function event configuration.
  * @param event Queue function event configuration
  * @returns Cleaned queue function event configuration
- */
 function buildQueueFunctionEvent(event: BlueprintQueueFunctionConfigEvent): BlueprintQueueFunctionResourceEvent {
-  const defaultEvent = {concurrency: 1, fifo: true, dlq: true}
+  const defaultEvent = { concurrency: 1, fifo: true, dlq: true }
   if (typeof event === 'boolean') {
     return defaultEvent
   }
@@ -527,6 +516,7 @@ function buildQueueFunctionEvent(event: BlueprintQueueFunctionConfigEvent): Blue
     ...userProvidedEvent,
   } as BlueprintQueueFunctionResourceEvent
 }
+*/
 
 /**
  * Defines a workflow function resource.
@@ -553,14 +543,14 @@ function buildQueueFunctionEvent(event: BlueprintQueueFunctionConfigEvent): Blue
  * @returns The validated workflow function resource
  */
 export function defineWorkflow(functionConfig: BlueprintWorkflowFunctionConfig): BlueprintWorkflowFunctionResource {
-  const {name, event, concurrency, debounce, debounceKey, src} = functionConfig
+  const { name, event, concurrency, debounce, debounceKey, src } = functionConfig
   const functionResource: BlueprintWorkflowFunctionResource = {
-    ...defineFunction({...functionConfig, src: src ?? `workflows/${name}`}, {skipValidation: true}),
+    ...defineFunction({ ...functionConfig, src: src ?? `workflows/${name}` }, { skipValidation: true }),
     type: 'sanity.function.workflow',
     event,
-    ...(concurrency !== undefined && {concurrency}),
-    ...(debounce !== undefined && {debounce}),
-    ...(debounceKey !== undefined && {debounceKey}),
+    ...(concurrency !== undefined && { concurrency }),
+    ...(debounce !== undefined && { debounce }),
+    ...(debounceKey !== undefined && { debounceKey }),
   }
 
   runValidation(() => validateWorkflowFunction(functionResource))

--- a/src/types/functions/event.ts
+++ b/src/types/functions/event.ts
@@ -118,12 +118,3 @@ export interface BlueprintFunctionResourceEventResourceMediaLibrary {
  * @category Functions Types
  */
 export type BlueprintFunctionResourceEventName = 'publish' | 'create' | 'delete' | 'update'
-
-/**
- * Event configuration for workflows.
- * @category Functions Types
- */
-export type BlueprintWorkflowFunctionResourceEvent =
-  | ({type: 'document'} & BlueprintDocumentFunctionResourceEvent)
-  | ({type: 'sync-tag-invalidate'} & BlueprintSyncTagInvalidateFunctionResourceEvent)
-  | ({type: 'media-library'} & BlueprintMediaLibraryFunctionResourceEvent)

--- a/src/types/functions/event.ts
+++ b/src/types/functions/event.ts
@@ -84,31 +84,12 @@ export type BlueprintScheduledFunctionConfigEvent =
   | BlueprintScheduledFunctionExpressionResourceEvent
 
 /**
- * Event configuration for queue functions
- * @category Functions Types
- * @alpha
- * @hidden
- */
-export interface BlueprintQueueFunctionResourceEvent {
-  concurrency?: number
-  fifo?: boolean
-  dlq?: boolean
-}
-
-/**
- * Union type of all queue function resource event configurations
- * @category Functions Types
- */
-export type BlueprintQueueFunctionConfigEvent = true | BlueprintQueueFunctionResourceEvent
-
-/**
  * Union type of all function resource event configurations
  * @category Functions Types
  */
 export type BlueprintFunctionResourceEvent =
   | BlueprintDocumentFunctionResourceEvent
   | BlueprintMediaLibraryFunctionResourceEvent
-  | BlueprintQueueFunctionResourceEvent
   | BlueprintScheduledFunctionResourceEvent
   | BlueprintSyncTagInvalidateFunctionResourceEvent
 

--- a/src/types/functions/event.ts
+++ b/src/types/functions/event.ts
@@ -88,10 +88,10 @@ export type BlueprintScheduledFunctionConfigEvent =
  * @category Functions Types
  */
 export type BlueprintFunctionResourceEvent =
-  | BlueprintDocumentFunctionResourceEvent
-  | BlueprintMediaLibraryFunctionResourceEvent
-  | BlueprintScheduledFunctionResourceEvent
-  | BlueprintSyncTagInvalidateFunctionResourceEvent
+  | ({type: 'document'} & BlueprintDocumentFunctionResourceEvent)
+  | ({type: 'media-library'} & BlueprintMediaLibraryFunctionResourceEvent)
+  | ({type: 'cron'} & BlueprintScheduledFunctionResourceEvent)
+  | ({type: 'sync-tag-invalidate'} & BlueprintSyncTagInvalidateFunctionResourceEvent)
 
 /**
  * Dataset resource for scoping document functions to specific datasets

--- a/src/types/functions/index.ts
+++ b/src/types/functions/index.ts
@@ -6,7 +6,6 @@ import type {
   BlueprintScheduledFunctionConfigEvent,
   BlueprintScheduledFunctionResourceEvent,
   BlueprintSyncTagInvalidateFunctionResourceEvent,
-  BlueprintWorkflowFunctionResourceEvent,
 } from './event.js'
 import type {IanaTimezone} from './timezone.js'
 
@@ -257,7 +256,7 @@ export type BlueprintEventFunctionConfig = Omit<BlueprintEventFunctionResource, 
  */
 export interface BlueprintWorkflowFunctionResource extends BlueprintBaseFunctionResource {
   type: 'sanity.function.workflow'
-  event?: BlueprintWorkflowFunctionResourceEvent
+  event?: BlueprintFunctionResourceEvent
   /**
    * Concurrent executions
    * Min 1
@@ -291,5 +290,5 @@ export type BlueprintWorkflowFunctionConfig = Omit<BlueprintWorkflowFunctionReso
   /**
    * Trigger configuration
    */
-  event?: BlueprintWorkflowFunctionResourceEvent
+  event?: BlueprintFunctionResourceEvent
 }

--- a/src/types/functions/index.ts
+++ b/src/types/functions/index.ts
@@ -2,7 +2,6 @@ import type {BlueprintResource} from '../../index.js'
 import type {
   BlueprintDocumentFunctionResourceEvent,
   BlueprintMediaLibraryFunctionResourceEvent,
-  BlueprintQueueFunctionResourceEvent,
   BlueprintScheduledFunctionConfigEvent,
   BlueprintScheduledFunctionResourceEvent,
   BlueprintSyncTagInvalidateFunctionResourceEvent,
@@ -109,7 +108,6 @@ export interface BlueprintSyncTagInvalidateFunctionResource extends BlueprintBas
  */
 export interface BlueprintQueueFunctionResource extends BlueprintBaseFunctionResource {
   type: 'sanity.function.queue'
-  event?: BlueprintQueueFunctionResourceEvent
 }
 
 /**

--- a/src/types/functions/index.ts
+++ b/src/types/functions/index.ts
@@ -2,7 +2,6 @@ import type {BlueprintResource} from '../../index.js'
 import type {
   BlueprintDocumentFunctionResourceEvent,
   BlueprintMediaLibraryFunctionResourceEvent,
-  BlueprintQueueFunctionConfigEvent,
   BlueprintQueueFunctionResourceEvent,
   BlueprintScheduledFunctionConfigEvent,
   BlueprintScheduledFunctionResourceEvent,
@@ -222,17 +221,10 @@ export type BlueprintQueueFunctionConfig = Omit<BlueprintQueueFunctionResource, 
    * @defaultValue `functions/${name}`
    */
   src?: string
-  /**
-   * Queue configuration.
-   *
-   * Omit this property or set it to `true` to use the defaults:
-   * concurrency: 1, fifo: true, dlq: true.
-   *
-   * Provide an object to override specific settings.
-   *
-   * @defaultValue true
-   */
-  queue?: BlueprintQueueFunctionConfigEvent
+
+  concurrency?: number
+  fifo?: boolean
+  dlq?: boolean
 }
 
 /**

--- a/src/types/functions/index.ts
+++ b/src/types/functions/index.ts
@@ -1,6 +1,7 @@
 import type {BlueprintResource} from '../../index.js'
 import type {
   BlueprintDocumentFunctionResourceEvent,
+  BlueprintFunctionResourceEvent,
   BlueprintMediaLibraryFunctionResourceEvent,
   BlueprintScheduledFunctionConfigEvent,
   BlueprintScheduledFunctionResourceEvent,
@@ -108,6 +109,8 @@ export interface BlueprintSyncTagInvalidateFunctionResource extends BlueprintBas
  */
 export interface BlueprintQueueFunctionResource extends BlueprintBaseFunctionResource {
   type: 'sanity.function.queue'
+  /** Optional event configuration that triggers the function */
+  event?: BlueprintFunctionResourceEvent
 }
 
 /**
@@ -219,6 +222,9 @@ export type BlueprintQueueFunctionConfig = Omit<BlueprintQueueFunctionResource, 
    * @defaultValue `functions/${name}`
    */
   src?: string
+
+  /** Optional event configuration that triggers the queue function */
+  event?: BlueprintFunctionResourceEvent
 
   concurrency?: number
   fifo?: boolean

--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -464,7 +464,7 @@ export function validateQueueFunction(functionResource: unknown): BlueprintError
   }
 
   if ('event' in functionResource && typeof functionResource.event !== 'undefined') {
-    errors.push(...validateQueueFunctionEvent(functionResource.event))
+    errors.push(...validateFunctionEvent(functionResource.event))
   }
 
   errors.push(...validateFunction(functionResource))
@@ -473,15 +473,25 @@ export function validateQueueFunction(functionResource: unknown): BlueprintError
 }
 
 /**
- * Validates a queue function event configuration.
+ * Validates a function event configuration.
  * The event is a discriminated union keyed by `type`; validation is delegated to the
  * matching per-type event validator.
  * @param event The event configuration to validate
  * @returns Array of validation errors, empty if valid
  */
-function validateQueueFunctionEvent(event: unknown): BlueprintError[] {
+function validateFunctionEvent(event: unknown): BlueprintError[] {
   if (!event || typeof event !== 'object') return [{type: 'invalid_type', message: '`event` must be an object'}]
   if (!('type' in event)) return [{type: 'missing_parameter', message: '`event.type` is required'}]
+
+  if (
+    'type' in event &&
+    event.type !== 'document' &&
+    event.type !== 'sync-tag-invalidate' &&
+    event.type !== 'media-library' &&
+    event.type !== 'cron'
+  ) {
+    return [{type: 'invalid_value', message: '`event.type` must be either `cron`, `document`, `sync-tag-invalidate`, or `media-library`'}]
+  }
 
   switch (event.type) {
     case 'document':
@@ -522,38 +532,6 @@ export function validateEventFunction(functionResource: unknown): BlueprintError
   }
 
   errors.push(...validateFunction(functionResource))
-
-  return errors
-}
-
-/**
- * Validates a workflow function event configuration.
- * @param event The event configuration to validate
- * @returns Array of validation errors, empty if valid
- */
-function validateWorkflowFunctionEvent(event: unknown): BlueprintError[] {
-  if (!event || typeof event !== 'object') return [{type: 'invalid_type', message: '`event` must be an object'}]
-  if (!('type' in event)) {
-    return [{type: 'invalid_value', message: '`event.type` must be provided'}]
-  }
-
-  if ('type' in event && event.type !== 'document' && event.type !== 'sync-tag-invalidate' && event.type !== 'media-library') {
-    return [{type: 'invalid_value', message: '`event.type` must be either `document`, `sync-tag-invalidate`, or `media-library`'}]
-  }
-
-  const errors: BlueprintError[] = []
-
-  switch (event.type) {
-    case 'document':
-      errors.push(...validateDocumentFunctionEvent(event))
-      break
-    case 'sync-tag-invalidate':
-      errors.push(...validateFunctionEventResourceDataset(event))
-      break
-    case 'media-library':
-      errors.push(...validateMediaLibraryFunctionEvent(event))
-      break
-  }
 
   return errors
 }
@@ -601,7 +579,7 @@ export function validateWorkflowFunction(functionResource: unknown): BlueprintEr
   }
 
   if ('event' in functionResource) {
-    errors.push(...validateWorkflowFunctionEvent(functionResource.event))
+    errors.push(...validateFunctionEvent(functionResource.event))
   }
 
   errors.push(...validateFunction(functionResource))

--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -181,7 +181,9 @@ function validateDocumentFunctionEvent(event: unknown): BlueprintError[] {
 function validateFunctionEventResourceDataset(event: unknown): BlueprintError[] {
   const errors: BlueprintError[] = []
   if (!event || typeof event !== 'object') return [{type: 'invalid_value', message: '`event` must be an object'}]
-  if (!('resource' in event)) return [{type: 'invalid_value', message: '`event.resource` must exist'}]
+  // `resource` is optional for the event types that reach here (document and sync-tag-invalidate),
+  // so there is nothing to validate when it is absent.
+  if (!('resource' in event) || typeof event.resource === 'undefined') return []
   const resource = event.resource
   if (!resource || typeof resource !== 'object') return [{type: 'invalid_value', message: '`event.resource` must be an object'}]
   if (!('type' in resource) || !resource.type || resource.type !== 'dataset')
@@ -454,6 +456,8 @@ export function validateQueueFunction(functionResource: unknown): BlueprintError
       errors.push({type: 'invalid_type', message: '`concurrency` must be a number'})
     } else if (functionResource.concurrency < 1) {
       errors.push({type: 'invalid_type', message: '`concurrency` must be at least 1'})
+    } else if (functionResource.concurrency > 500) {
+      errors.push({type: 'invalid_value', message: '`concurrency` must be less than 500'})
     }
   }
   if ('fifo' in functionResource && typeof functionResource.fifo !== 'boolean') {
@@ -483,16 +487,6 @@ function validateFunctionEvent(event: unknown): BlueprintError[] {
   if (!event || typeof event !== 'object') return [{type: 'invalid_type', message: '`event` must be an object'}]
   if (!('type' in event)) return [{type: 'missing_parameter', message: '`event.type` is required'}]
 
-  if (
-    'type' in event &&
-    event.type !== 'document' &&
-    event.type !== 'sync-tag-invalidate' &&
-    event.type !== 'media-library' &&
-    event.type !== 'cron'
-  ) {
-    return [{type: 'invalid_value', message: '`event.type` must be either `cron`, `document`, `sync-tag-invalidate`, or `media-library`'}]
-  }
-
   switch (event.type) {
     case 'document':
       return validateDocumentFunctionEvent(event)
@@ -506,7 +500,7 @@ function validateFunctionEvent(event: unknown): BlueprintError[] {
       return [
         {
           type: 'invalid_value',
-          message: '`event.type` must be one of "document", "media-library", "cron", "sync-tag-invalidate"',
+          message: '`event.type` must be either `cron`, `document`, `sync-tag-invalidate`, or `media-library`',
         },
       ]
   }

--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -463,33 +463,44 @@ export function validateQueueFunction(functionResource: unknown): BlueprintError
     errors.push({type: 'invalid_type', message: '`dlq` must be a boolean'})
   }
 
+  if ('event' in functionResource && typeof functionResource.event !== 'undefined') {
+    errors.push(...validateQueueFunctionEvent(functionResource.event))
+  }
+
   errors.push(...validateFunction(functionResource))
 
   return errors
 }
 
-/*
+/**
+ * Validates a queue function event configuration.
+ * The event is a discriminated union keyed by `type`; validation is delegated to the
+ * matching per-type event validator.
+ * @param event The event configuration to validate
+ * @returns Array of validation errors, empty if valid
+ */
 function validateQueueFunctionEvent(event: unknown): BlueprintError[] {
-  if (!event || typeof event !== 'object') return [{ type: 'invalid_type', message: '`event` must be an object' }]
+  if (!event || typeof event !== 'object') return [{type: 'invalid_type', message: '`event` must be an object'}]
+  if (!('type' in event)) return [{type: 'missing_parameter', message: '`event.type` is required'}]
 
-  const errors: BlueprintError[] = []
-
-  if (!('concurrency' in event) || typeof event.concurrency !== 'number') {
-    errors.push({ type: 'invalid_type', message: '`event.concurrency` must be a number' })
+  switch (event.type) {
+    case 'document':
+      return validateDocumentFunctionEvent(event)
+    case 'media-library':
+      return validateMediaLibraryFunctionEvent(event)
+    case 'cron':
+      return validateScheduledFunctionEvent(event)
+    case 'sync-tag-invalidate':
+      return validateFunctionEventResourceDataset(event)
+    default:
+      return [
+        {
+          type: 'invalid_value',
+          message: '`event.type` must be one of "document", "media-library", "cron", "sync-tag-invalidate"',
+        },
+      ]
   }
-  if ('concurrency' in event && typeof event.concurrency === 'number' && event.concurrency < 1) {
-    errors.push({ type: 'invalid_type', message: '`event.concurrency` must be at least 1' })
-  }
-  if (!('fifo' in event) || typeof event.fifo !== 'boolean') {
-    errors.push({ type: 'invalid_type', message: '`event.fifo` must be a boolean' })
-  }
-  if (!('dlq' in event) || typeof event.dlq !== 'boolean') {
-    errors.push({ type: 'invalid_type', message: '`event.dlq` must be a boolean' })
-  }
-
-  return errors
 }
-*/
 
 /**
  * Validates an event function resource configuration.

--- a/src/validation/functions.ts
+++ b/src/validation/functions.ts
@@ -449,8 +449,18 @@ export function validateQueueFunction(functionResource: unknown): BlueprintError
     errors.push({type: 'invalid_value', message: '`type` must be `sanity.function.queue`'})
   }
 
-  if ('event' in functionResource) {
-    errors.push(...validateQueueFunctionEvent(functionResource.event))
+  if ('concurrency' in functionResource) {
+    if (typeof functionResource.concurrency !== 'number') {
+      errors.push({type: 'invalid_type', message: '`concurrency` must be a number'})
+    } else if (functionResource.concurrency < 1) {
+      errors.push({type: 'invalid_type', message: '`concurrency` must be at least 1'})
+    }
+  }
+  if ('fifo' in functionResource && typeof functionResource.fifo !== 'boolean') {
+    errors.push({type: 'invalid_type', message: '`fifo` must be a boolean'})
+  }
+  if ('dlq' in functionResource && typeof functionResource.dlq !== 'boolean') {
+    errors.push({type: 'invalid_type', message: '`dlq` must be a boolean'})
   }
 
   errors.push(...validateFunction(functionResource))
@@ -458,26 +468,28 @@ export function validateQueueFunction(functionResource: unknown): BlueprintError
   return errors
 }
 
+/*
 function validateQueueFunctionEvent(event: unknown): BlueprintError[] {
-  if (!event || typeof event !== 'object') return [{type: 'invalid_type', message: '`event` must be an object'}]
+  if (!event || typeof event !== 'object') return [{ type: 'invalid_type', message: '`event` must be an object' }]
 
   const errors: BlueprintError[] = []
 
   if (!('concurrency' in event) || typeof event.concurrency !== 'number') {
-    errors.push({type: 'invalid_type', message: '`event.concurrency` must be a number'})
+    errors.push({ type: 'invalid_type', message: '`event.concurrency` must be a number' })
   }
   if ('concurrency' in event && typeof event.concurrency === 'number' && event.concurrency < 1) {
-    errors.push({type: 'invalid_type', message: '`event.concurrency` must be at least 1'})
+    errors.push({ type: 'invalid_type', message: '`event.concurrency` must be at least 1' })
   }
   if (!('fifo' in event) || typeof event.fifo !== 'boolean') {
-    errors.push({type: 'invalid_type', message: '`event.fifo` must be a boolean'})
+    errors.push({ type: 'invalid_type', message: '`event.fifo` must be a boolean' })
   }
   if (!('dlq' in event) || typeof event.dlq !== 'boolean') {
-    errors.push({type: 'invalid_type', message: '`event.dlq` must be a boolean'})
+    errors.push({ type: 'invalid_type', message: '`event.dlq` must be a boolean' })
   }
 
   return errors
 }
+*/
 
 /**
  * Validates an event function resource configuration.

--- a/test/integration/resources.typecheck.ts
+++ b/test/integration/resources.typecheck.ts
@@ -11,8 +11,7 @@ import {
   type BlueprintDocumentWebhookConfig,
   type BlueprintDocumentWebhookResource,
   type BlueprintEventFunctionResource,
-  // type BlueprintFunctionBaseResourceEvent,
-  // type BlueprintFunctionResourceEvent,
+  type BlueprintFunctionResourceEvent,
   type BlueprintMediaLibraryAssetFunctionResource,
   type BlueprintMediaLibraryFunctionResourceEvent,
   type BlueprintModule,
@@ -28,7 +27,6 @@ import {
   type BlueprintSyncTagInvalidateFunctionResource,
   type BlueprintSyncTagInvalidateFunctionResourceEvent,
   type BlueprintWorkflowFunctionResource,
-  type BlueprintWorkflowFunctionResourceEvent,
   defineCorsOrigin,
   defineDataset,
   defineDocumentFunction,
@@ -83,12 +81,12 @@ const datasetConfig: BlueprintDatasetConfig = {
 }
 const datasetResource: BlueprintDatasetResource = defineDataset(datasetConfig)
 
-const _workflowDocumentEvent: BlueprintWorkflowFunctionResourceEvent = {
+const _workflowDocumentEvent: BlueprintFunctionResourceEvent = {
   type: 'document',
   on: ['create'],
   filter: "_type == 'article'",
 }
-const _workflowSyncTagEvent: BlueprintWorkflowFunctionResourceEvent = {
+const _workflowSyncTagEvent: BlueprintFunctionResourceEvent = {
   type: 'sync-tag-invalidate',
   resource: {type: 'dataset', id: 'proj.dataset'},
 }

--- a/test/integration/resources.typecheck.ts
+++ b/test/integration/resources.typecheck.ts
@@ -138,7 +138,6 @@ const syncTagInvalidateFunction: BlueprintSyncTagInvalidateFunctionResource = de
 
 const queueFunction: BlueprintQueueFunctionResource = defineQueueFunction({
   name: 'stuff',
-  queue: true,
 })
 
 const eventFunction: BlueprintEventFunctionResource = defineEventFunction({

--- a/test/unit/definers/functions.test.ts
+++ b/test/unit/definers/functions.test.ts
@@ -1,7 +1,8 @@
-import {afterEach, describe, expect, test, vi} from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import * as fns from '../../../src/definers/functions.js'
+import type { BlueprintFunctionResourceEvent } from '../../../src/index.js'
 import * as index from '../../../src/index.js'
-import {defineBlueprintForResource} from '../../helpers/index.js'
+import { defineBlueprintForResource } from '../../helpers/index.js'
 
 vi.mock(import('../../../src/index.js'), async (importOriginal) => {
   const originalModule = await importOriginal()
@@ -14,13 +15,13 @@ vi.mock(import('../../../src/index.js'), async (importOriginal) => {
 describe('defineFunction', () => {
   describe('happy paths', () => {
     test('should assign src based on name if not provided', () => {
-      const fn = fns.defineFunction({name: 'test'})
+      const fn = fns.defineFunction({ name: 'test' })
       expect(fn.src).toEqual('functions/test')
     })
 
     test('should ignore invalid properties', () => {
       // @ts-expect-error Intentionally wrong type
-      const fn = fns.defineFunction({name: 'test', invalid: 'invalid'})
+      const fn = fns.defineFunction({ name: 'test', invalid: 'invalid' })
       expect(Object.keys(fn)).not.toContain('invalid')
     })
   })
@@ -30,8 +31,8 @@ describe('defineFunction', () => {
     })
 
     test('should throw an error if validateFunction returns an error', () => {
-      const spy = vi.spyOn(index, 'validateFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
-      expect(() => defineBlueprintForResource(fns.defineFunction({name: 'func-name'}))).toThrow('this is a test')
+      const spy = vi.spyOn(index, 'validateFunction').mockImplementation(() => [{ type: 'test', message: 'this is a test' }])
+      expect(() => defineBlueprintForResource(fns.defineFunction({ name: 'func-name' }))).toThrow('this is a test')
 
       expect(spy).toHaveBeenCalledOnce()
     })
@@ -40,27 +41,27 @@ describe('defineFunction', () => {
 describe('defineDocumentFunction', () => {
   describe('happy paths', () => {
     test('should create a default publish event with provided filter', () => {
-      const fn = fns.defineDocumentFunction({name: 'test', event: {filter: '_type == "post"'}})
-      expect(fn.event).toEqual({on: ['publish'], filter: '_type == "post"'})
+      const fn = fns.defineDocumentFunction({ name: 'test', event: { filter: '_type == "post"' } })
+      expect(fn.event).toEqual({ on: ['publish'], filter: '_type == "post"' })
     })
 
     test('should throw an error if event keys are defined using a mix of under the event object as well as at the top level', () => {
       expect(() =>
         fns.defineDocumentFunction({
           name: 'test',
-          event: {on: ['publish']},
+          event: { on: ['publish'] },
           filter: '_type == "post"',
         }),
       ).toThrowError(/`event` properties should be specified under the `event` key/i)
     })
 
     test('should create the event with publish if not provided', () => {
-      const fn = fns.defineDocumentFunction({name: 'test', src: 'test.js'})
-      expect(fn.event).toEqual({on: ['publish']})
+      const fn = fns.defineDocumentFunction({ name: 'test', src: 'test.js' })
+      expect(fn.event).toEqual({ on: ['publish'] })
     })
 
     test('should allow for creating events triggered on create, update and delete', () => {
-      const fn = fns.defineDocumentFunction({name: 'test', src: 'test.js', event: {on: ['create', 'update', 'delete']}})
+      const fn = fns.defineDocumentFunction({ name: 'test', src: 'test.js', event: { on: ['create', 'update', 'delete'] } })
       expect(fn.event.on).toEqual(['create', 'update', 'delete'])
     })
 
@@ -68,7 +69,7 @@ describe('defineDocumentFunction', () => {
       const fn = fns.defineDocumentFunction({
         name: 'test',
         src: 'test.js',
-        event: {on: ['update'], includeAllVersions: true, includeDrafts: true},
+        event: { on: ['update'], includeAllVersions: true, includeDrafts: true },
       })
       expect(fn.event.includeDrafts).toEqual(true)
       expect(fn.event.includeAllVersions).toEqual(true)
@@ -78,7 +79,7 @@ describe('defineDocumentFunction', () => {
       const fn = fns.defineDocumentFunction({
         name: 'test',
         src: 'test.js',
-        event: {on: ['update'], resource: {type: 'dataset', id: 'myProject.myDataset'}},
+        event: { on: ['update'], resource: { type: 'dataset', id: 'myProject.myDataset' } },
       })
       expect(fn.event.resource?.type).toEqual('dataset')
       expect(fn.event.resource?.id).toEqual('myProject.myDataset')
@@ -88,7 +89,7 @@ describe('defineDocumentFunction', () => {
       const fn = fns.defineDocumentFunction({
         name: 'test',
         src: 'test.js',
-        event: {on: ['update'], resource: {type: 'dataset', id: 'myProject.*'}},
+        event: { on: ['update'], resource: { type: 'dataset', id: 'myProject.*' } },
       })
       expect(fn.event.resource?.type).toEqual('dataset')
       expect(fn.event.resource?.id).toEqual('myProject.*')
@@ -98,7 +99,7 @@ describe('defineDocumentFunction', () => {
       const fn = fns.defineDocumentFunction({
         name: 'test',
         src: 'test.js',
-        event: {on: ['update']},
+        event: { on: ['update'] },
         project: 'projectId',
       })
       expect(fn.project).toEqual('projectId')
@@ -111,8 +112,8 @@ describe('defineDocumentFunction', () => {
     })
 
     test('should throw an error if validateDocumentFunction returns an error', () => {
-      const spy = vi.spyOn(index, 'validateDocumentFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
-      expect(() => defineBlueprintForResource(fns.defineDocumentFunction({name: 'test', event: {on: ['publish']}}))).toThrow(
+      const spy = vi.spyOn(index, 'validateDocumentFunction').mockImplementation(() => [{ type: 'test', message: 'this is a test' }])
+      expect(() => defineBlueprintForResource(fns.defineDocumentFunction({ name: 'test', event: { on: ['publish'] } }))).toThrow(
         'this is a test',
       )
 
@@ -122,10 +123,10 @@ describe('defineDocumentFunction', () => {
 })
 
 describe('defineMediaLibraryAssetFunction', () => {
-  const resource = {type: 'media-library' as const, id: 'ml12345'}
+  const resource = { type: 'media-library' as const, id: 'ml12345' }
   describe('happy paths', () => {
     test('should create a default publish event with provided filter', () => {
-      const event = {filter: '_type == "post"', resource}
+      const event = { filter: '_type == "post"', resource }
       const fn = fns.defineMediaLibraryAssetFunction({
         name: 'test',
         event,
@@ -135,12 +136,12 @@ describe('defineMediaLibraryAssetFunction', () => {
     })
 
     test('should create the event with publish if not provided', () => {
-      const fn = fns.defineMediaLibraryAssetFunction({name: 'test', src: 'test.js', event: {resource}})
+      const fn = fns.defineMediaLibraryAssetFunction({ name: 'test', src: 'test.js', event: { resource } })
       expect(fn.event.on).toEqual(['publish'])
     })
 
     test('should allow for creating events triggered on create, update and delete', () => {
-      const fn = fns.defineMediaLibraryAssetFunction({name: 'test', src: 'test.js', event: {on: ['create', 'update', 'delete'], resource}})
+      const fn = fns.defineMediaLibraryAssetFunction({ name: 'test', src: 'test.js', event: { on: ['create', 'update', 'delete'], resource } })
       expect(fn.event.on).toEqual(['create', 'update', 'delete'])
     })
 
@@ -148,13 +149,13 @@ describe('defineMediaLibraryAssetFunction', () => {
       let fn = fns.defineMediaLibraryAssetFunction({
         name: 'test',
         src: 'test.js',
-        event: {on: ['update'], includeDrafts: true, resource},
+        event: { on: ['update'], includeDrafts: true, resource },
       })
       expect(fn.event.includeDrafts).toEqual(true)
       fn = fns.defineMediaLibraryAssetFunction({
         name: 'test',
         src: 'test.js',
-        event: {on: ['update'], includeDrafts: false, resource},
+        event: { on: ['update'], includeDrafts: false, resource },
       })
       expect(fn.event.includeDrafts).toEqual(false)
     })
@@ -163,7 +164,7 @@ describe('defineMediaLibraryAssetFunction', () => {
       const fn = fns.defineMediaLibraryAssetFunction({
         name: 'test',
         src: 'test.js',
-        event: {on: ['update'], resource},
+        event: { on: ['update'], resource },
         project: 'projectId',
       })
       expect(fn.project).toEqual('projectId')
@@ -176,10 +177,10 @@ describe('defineMediaLibraryAssetFunction', () => {
     })
 
     test('should throw an error if validateMediaLibraryAssetFunction returns an error', () => {
-      const spy = vi.spyOn(index, 'validateMediaLibraryAssetFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
+      const spy = vi.spyOn(index, 'validateMediaLibraryAssetFunction').mockImplementation(() => [{ type: 'test', message: 'this is a test' }])
       expect(() =>
         defineBlueprintForResource(
-          fns.defineMediaLibraryAssetFunction({name: 'test', event: {on: ['publish'], resource: {type: 'media-library', id: 'ml1234'}}}),
+          fns.defineMediaLibraryAssetFunction({ name: 'test', event: { on: ['publish'], resource: { type: 'media-library', id: 'ml1234' } } }),
         ),
       ).toThrow('this is a test')
 
@@ -191,95 +192,95 @@ describe('defineMediaLibraryAssetFunction', () => {
 describe('defineScheduledFunction', () => {
   describe('happy paths', () => {
     test('should create a scheduled event with explicit cron fields', () => {
-      const event = {minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'}
+      const event = { minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*' }
       const fn = fns.defineScheduledFunction({
         name: 'test',
         event,
       })
-      expect(fn.event).toEqual({minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'})
+      expect(fn.event).toEqual({ minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*' })
     })
 
     test('should normalize expression to explicit cron fields', () => {
-      const event = {expression: '* * * * *'}
+      const event = { expression: '* * * * *' }
       const fn = fns.defineScheduledFunction({
         name: 'test',
         event,
       })
-      expect(fn.event).toEqual({minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'})
+      expect(fn.event).toEqual({ minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*' })
     })
 
     test('should create a scheduled function with optional timezone', () => {
       const fn = fns.defineScheduledFunction({
         name: 'test',
-        event: {expression: '* * * * *'},
+        event: { expression: '* * * * *' },
         timezone: 'America/New_York',
       })
       expect(fn.timezone).toEqual('America/New_York')
-      expect(fn.event).toEqual({minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'})
+      expect(fn.event).toEqual({ minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*' })
     })
 
     test('should parse natural language expression to explicit cron fields', () => {
       const fn = fns.defineScheduledFunction({
         name: 'test',
-        event: {expression: 'every day at 9am'},
+        event: { expression: 'every day at 9am' },
       })
-      expect(fn.event).toEqual({minute: '0', hour: '9', dayOfMonth: '*', month: '*', dayOfWeek: '*'})
+      expect(fn.event).toEqual({ minute: '0', hour: '9', dayOfMonth: '*', month: '*', dayOfWeek: '*' })
     })
 
     test('should normalize cron expression to explicit fields', () => {
       const fn = fns.defineScheduledFunction({
         name: 'test',
-        event: {expression: '0 9 * * 1-5'},
+        event: { expression: '0 9 * * 1-5' },
       })
-      expect(fn.event).toEqual({minute: '0', hour: '9', dayOfMonth: '*', month: '*', dayOfWeek: '1-5'})
+      expect(fn.event).toEqual({ minute: '0', hour: '9', dayOfMonth: '*', month: '*', dayOfWeek: '1-5' })
     })
 
     test('should parse weekday natural language', () => {
       const fn = fns.defineScheduledFunction({
         name: 'test',
-        event: {expression: 'weekdays at 8am'},
+        event: { expression: 'weekdays at 8am' },
       })
-      expect(fn.event).toEqual({minute: '0', hour: '8', dayOfMonth: '*', month: '*', dayOfWeek: '1-5'})
+      expect(fn.event).toEqual({ minute: '0', hour: '8', dayOfMonth: '*', month: '*', dayOfWeek: '1-5' })
     })
 
     test('should parse specific weekday with time', () => {
       const fn = fns.defineScheduledFunction({
         name: 'test',
-        event: {expression: 'fridays at 9am'},
+        event: { expression: 'fridays at 9am' },
       })
-      expect(fn.event).toEqual({minute: '0', hour: '9', dayOfMonth: '*', month: '*', dayOfWeek: '5'})
+      expect(fn.event).toEqual({ minute: '0', hour: '9', dayOfMonth: '*', month: '*', dayOfWeek: '5' })
     })
 
     test('should parse time of day period', () => {
       const fn = fns.defineScheduledFunction({
         name: 'test',
-        event: {expression: 'fridays in the evening'},
+        event: { expression: 'fridays in the evening' },
       })
-      expect(fn.event).toEqual({minute: '0', hour: '18', dayOfMonth: '*', month: '*', dayOfWeek: '5'})
+      expect(fn.event).toEqual({ minute: '0', hour: '18', dayOfMonth: '*', month: '*', dayOfWeek: '5' })
     })
 
     test('should parse multiple weekdays', () => {
       const fn = fns.defineScheduledFunction({
         name: 'test',
-        event: {expression: 'mon, wed, fri at 9am'},
+        event: { expression: 'mon, wed, fri at 9am' },
       })
-      expect(fn.event).toEqual({minute: '0', hour: '9', dayOfMonth: '*', month: '*', dayOfWeek: '1,3,5'})
+      expect(fn.event).toEqual({ minute: '0', hour: '9', dayOfMonth: '*', month: '*', dayOfWeek: '1,3,5' })
     })
 
     test('should parse interval schedules', () => {
       const fn = fns.defineScheduledFunction({
         name: 'test',
-        event: {expression: 'every 15 minutes'},
+        event: { expression: 'every 15 minutes' },
       })
-      expect(fn.event).toEqual({minute: '*/15', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'})
+      expect(fn.event).toEqual({ minute: '*/15', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*' })
     })
 
     test('deprecated method defineScheduleFunction should work', () => {
       const fn = fns.defineScheduleFunction({
         name: 'test',
-        event: {expression: 'every 15 minutes'},
+        event: { expression: 'every 15 minutes' },
       })
-      expect(fn.event).toEqual({minute: '*/15', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'})
+      expect(fn.event).toEqual({ minute: '*/15', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*' })
     })
   })
 
@@ -289,10 +290,10 @@ describe('defineScheduledFunction', () => {
     })
 
     test('should throw an error if validateScheduledFunction returns an error', () => {
-      const spy = vi.spyOn(index, 'validateScheduledFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
+      const spy = vi.spyOn(index, 'validateScheduledFunction').mockImplementation(() => [{ type: 'test', message: 'this is a test' }])
       expect(() =>
         defineBlueprintForResource(
-          fns.defineScheduledFunction({name: 'test', event: {minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'}}),
+          fns.defineScheduledFunction({ name: 'test', event: { minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*' } }),
         ),
       ).toThrow('this is a test')
 
@@ -313,9 +314,9 @@ describe('defineWorkflow', () => {
     test('should create a workflow with an event', () => {
       const fn = fns.defineWorkflow({
         name: 'test',
-        event: {type: 'document', on: ['create'], filter: "_type == 'article'"},
+        event: { type: 'document', on: ['create'], filter: "_type == 'article'" },
       })
-      expect(fn.event).toEqual({type: 'document', on: ['create'], filter: "_type == 'article'"})
+      expect(fn.event).toEqual({ type: 'document', on: ['create'], filter: "_type == 'article'" })
     })
 
     test('should create a workflow function with optional concurrency', () => {
@@ -346,22 +347,81 @@ describe('defineWorkflow', () => {
       expect(fn.debounceKey).toEqual('testKey')
       expect(fn.name).toEqual('test')
     })
+
+    describe('sad paths', () => {
+      afterEach(() => {
+        vi.resetAllMocks()
+      })
+
+      test('should throw an error if validateWorkflowFunction returns an error', () => {
+        const spy = vi.spyOn(index, 'validateWorkflowFunction').mockImplementation(() => [{ type: 'test', message: 'this is a test' }])
+        expect(() =>
+          defineBlueprintForResource(
+            fns.defineWorkflow({ name: 'test', event: { type: 'document', on: ['create'], filter: "_type == 'article'" } }),
+          ),
+        ).toThrow('this is a test')
+
+        expect(spy).toHaveBeenCalledOnce()
+      })
+    })
   })
 
-  describe('sad paths', () => {
-    afterEach(() => {
-      vi.resetAllMocks()
+  describe('defineQueueFunction', () => {
+    describe('happy paths', () => {
+      test('should create a queue function without an event', () => {
+        const fn = fns.defineQueueFunction({ name: 'test' })
+        expect(fn.type).toEqual('sanity.function.queue')
+        expect(fn).not.toHaveProperty('event')
+      })
+
+      test('should pass through a document event', () => {
+        const event: BlueprintFunctionResourceEvent = { type: 'document', on: ['publish'], filter: "_type == 'post'" }
+        const fn = fns.defineQueueFunction({ name: 'test', event })
+        expect(fn.event).toEqual(event)
+      })
+
+      test('should pass through a media-library event', () => {
+        const event: BlueprintFunctionResourceEvent = {
+          type: 'media-library',
+          on: ['create'],
+          resource: { type: 'media-library', id: 'my-media-library-id' },
+        }
+        const fn = fns.defineQueueFunction({ name: 'test', event })
+        expect(fn.event).toEqual(event)
+      })
+
+      test('should pass through a cron event', () => {
+        const event: BlueprintFunctionResourceEvent = { type: 'cron', minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*' }
+        const fn = fns.defineQueueFunction({ name: 'test', event })
+        expect(fn.event).toEqual(event)
+      })
+
+      test('should pass through a sync-tag-invalidate event', () => {
+        const event: BlueprintFunctionResourceEvent = { type: 'sync-tag-invalidate', resource: { type: 'dataset', id: 'myProj.myDataset' } }
+        const fn = fns.defineQueueFunction({ name: 'test', event })
+        expect(fn.event).toEqual(event)
+      })
+
+      test('should pass through concurrency, fifo and dlq alongside an event', () => {
+        const event: BlueprintFunctionResourceEvent = { type: 'document', on: ['publish'] }
+        const fn = fns.defineQueueFunction({ name: 'test', event, concurrency: 5, fifo: false, dlq: false })
+        expect(fn).toMatchObject({ event, concurrency: 5, fifo: false, dlq: false })
+      })
     })
 
-    test('should throw an error if validateWorkflowFunction returns an error', () => {
-      const spy = vi.spyOn(index, 'validateWorkflowFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
-      expect(() =>
-        defineBlueprintForResource(
-          fns.defineWorkflow({name: 'test', event: {type: 'document', on: ['create'], filter: "_type == 'article'"}}),
-        ),
-      ).toThrow('this is a test')
+    describe('sad paths', () => {
+      afterEach(() => {
+        vi.resetAllMocks()
+      })
 
-      expect(spy).toHaveBeenCalledOnce()
+      test('should throw an error if validateQueueFunction returns an error', () => {
+        const spy = vi.spyOn(index, 'validateQueueFunction').mockImplementation(() => [{ type: 'test', message: 'this is a test' }])
+        expect(() => defineBlueprintForResource(fns.defineQueueFunction({ name: 'test', event: { type: 'document', on: ['publish'] } }))).toThrow(
+          'this is a test',
+        )
+
+        expect(spy).toHaveBeenCalledOnce()
+      })
     })
   })
 })

--- a/test/unit/definers/functions.test.ts
+++ b/test/unit/definers/functions.test.ts
@@ -1,8 +1,8 @@
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import {afterEach, describe, expect, test, vi} from 'vitest'
 import * as fns from '../../../src/definers/functions.js'
-import type { BlueprintFunctionResourceEvent } from '../../../src/index.js'
+import type {BlueprintFunctionResourceEvent} from '../../../src/index.js'
 import * as index from '../../../src/index.js'
-import { defineBlueprintForResource } from '../../helpers/index.js'
+import {defineBlueprintForResource} from '../../helpers/index.js'
 
 vi.mock(import('../../../src/index.js'), async (importOriginal) => {
   const originalModule = await importOriginal()
@@ -15,13 +15,13 @@ vi.mock(import('../../../src/index.js'), async (importOriginal) => {
 describe('defineFunction', () => {
   describe('happy paths', () => {
     test('should assign src based on name if not provided', () => {
-      const fn = fns.defineFunction({ name: 'test' })
+      const fn = fns.defineFunction({name: 'test'})
       expect(fn.src).toEqual('functions/test')
     })
 
     test('should ignore invalid properties', () => {
       // @ts-expect-error Intentionally wrong type
-      const fn = fns.defineFunction({ name: 'test', invalid: 'invalid' })
+      const fn = fns.defineFunction({name: 'test', invalid: 'invalid'})
       expect(Object.keys(fn)).not.toContain('invalid')
     })
   })
@@ -31,8 +31,8 @@ describe('defineFunction', () => {
     })
 
     test('should throw an error if validateFunction returns an error', () => {
-      const spy = vi.spyOn(index, 'validateFunction').mockImplementation(() => [{ type: 'test', message: 'this is a test' }])
-      expect(() => defineBlueprintForResource(fns.defineFunction({ name: 'func-name' }))).toThrow('this is a test')
+      const spy = vi.spyOn(index, 'validateFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
+      expect(() => defineBlueprintForResource(fns.defineFunction({name: 'func-name'}))).toThrow('this is a test')
 
       expect(spy).toHaveBeenCalledOnce()
     })
@@ -41,27 +41,27 @@ describe('defineFunction', () => {
 describe('defineDocumentFunction', () => {
   describe('happy paths', () => {
     test('should create a default publish event with provided filter', () => {
-      const fn = fns.defineDocumentFunction({ name: 'test', event: { filter: '_type == "post"' } })
-      expect(fn.event).toEqual({ on: ['publish'], filter: '_type == "post"' })
+      const fn = fns.defineDocumentFunction({name: 'test', event: {filter: '_type == "post"'}})
+      expect(fn.event).toEqual({on: ['publish'], filter: '_type == "post"'})
     })
 
     test('should throw an error if event keys are defined using a mix of under the event object as well as at the top level', () => {
       expect(() =>
         fns.defineDocumentFunction({
           name: 'test',
-          event: { on: ['publish'] },
+          event: {on: ['publish']},
           filter: '_type == "post"',
         }),
       ).toThrowError(/`event` properties should be specified under the `event` key/i)
     })
 
     test('should create the event with publish if not provided', () => {
-      const fn = fns.defineDocumentFunction({ name: 'test', src: 'test.js' })
-      expect(fn.event).toEqual({ on: ['publish'] })
+      const fn = fns.defineDocumentFunction({name: 'test', src: 'test.js'})
+      expect(fn.event).toEqual({on: ['publish']})
     })
 
     test('should allow for creating events triggered on create, update and delete', () => {
-      const fn = fns.defineDocumentFunction({ name: 'test', src: 'test.js', event: { on: ['create', 'update', 'delete'] } })
+      const fn = fns.defineDocumentFunction({name: 'test', src: 'test.js', event: {on: ['create', 'update', 'delete']}})
       expect(fn.event.on).toEqual(['create', 'update', 'delete'])
     })
 
@@ -69,7 +69,7 @@ describe('defineDocumentFunction', () => {
       const fn = fns.defineDocumentFunction({
         name: 'test',
         src: 'test.js',
-        event: { on: ['update'], includeAllVersions: true, includeDrafts: true },
+        event: {on: ['update'], includeAllVersions: true, includeDrafts: true},
       })
       expect(fn.event.includeDrafts).toEqual(true)
       expect(fn.event.includeAllVersions).toEqual(true)
@@ -79,7 +79,7 @@ describe('defineDocumentFunction', () => {
       const fn = fns.defineDocumentFunction({
         name: 'test',
         src: 'test.js',
-        event: { on: ['update'], resource: { type: 'dataset', id: 'myProject.myDataset' } },
+        event: {on: ['update'], resource: {type: 'dataset', id: 'myProject.myDataset'}},
       })
       expect(fn.event.resource?.type).toEqual('dataset')
       expect(fn.event.resource?.id).toEqual('myProject.myDataset')
@@ -89,7 +89,7 @@ describe('defineDocumentFunction', () => {
       const fn = fns.defineDocumentFunction({
         name: 'test',
         src: 'test.js',
-        event: { on: ['update'], resource: { type: 'dataset', id: 'myProject.*' } },
+        event: {on: ['update'], resource: {type: 'dataset', id: 'myProject.*'}},
       })
       expect(fn.event.resource?.type).toEqual('dataset')
       expect(fn.event.resource?.id).toEqual('myProject.*')
@@ -99,7 +99,7 @@ describe('defineDocumentFunction', () => {
       const fn = fns.defineDocumentFunction({
         name: 'test',
         src: 'test.js',
-        event: { on: ['update'] },
+        event: {on: ['update']},
         project: 'projectId',
       })
       expect(fn.project).toEqual('projectId')
@@ -112,8 +112,8 @@ describe('defineDocumentFunction', () => {
     })
 
     test('should throw an error if validateDocumentFunction returns an error', () => {
-      const spy = vi.spyOn(index, 'validateDocumentFunction').mockImplementation(() => [{ type: 'test', message: 'this is a test' }])
-      expect(() => defineBlueprintForResource(fns.defineDocumentFunction({ name: 'test', event: { on: ['publish'] } }))).toThrow(
+      const spy = vi.spyOn(index, 'validateDocumentFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
+      expect(() => defineBlueprintForResource(fns.defineDocumentFunction({name: 'test', event: {on: ['publish']}}))).toThrow(
         'this is a test',
       )
 
@@ -123,10 +123,10 @@ describe('defineDocumentFunction', () => {
 })
 
 describe('defineMediaLibraryAssetFunction', () => {
-  const resource = { type: 'media-library' as const, id: 'ml12345' }
+  const resource = {type: 'media-library' as const, id: 'ml12345'}
   describe('happy paths', () => {
     test('should create a default publish event with provided filter', () => {
-      const event = { filter: '_type == "post"', resource }
+      const event = {filter: '_type == "post"', resource}
       const fn = fns.defineMediaLibraryAssetFunction({
         name: 'test',
         event,
@@ -136,12 +136,12 @@ describe('defineMediaLibraryAssetFunction', () => {
     })
 
     test('should create the event with publish if not provided', () => {
-      const fn = fns.defineMediaLibraryAssetFunction({ name: 'test', src: 'test.js', event: { resource } })
+      const fn = fns.defineMediaLibraryAssetFunction({name: 'test', src: 'test.js', event: {resource}})
       expect(fn.event.on).toEqual(['publish'])
     })
 
     test('should allow for creating events triggered on create, update and delete', () => {
-      const fn = fns.defineMediaLibraryAssetFunction({ name: 'test', src: 'test.js', event: { on: ['create', 'update', 'delete'], resource } })
+      const fn = fns.defineMediaLibraryAssetFunction({name: 'test', src: 'test.js', event: {on: ['create', 'update', 'delete'], resource}})
       expect(fn.event.on).toEqual(['create', 'update', 'delete'])
     })
 
@@ -149,13 +149,13 @@ describe('defineMediaLibraryAssetFunction', () => {
       let fn = fns.defineMediaLibraryAssetFunction({
         name: 'test',
         src: 'test.js',
-        event: { on: ['update'], includeDrafts: true, resource },
+        event: {on: ['update'], includeDrafts: true, resource},
       })
       expect(fn.event.includeDrafts).toEqual(true)
       fn = fns.defineMediaLibraryAssetFunction({
         name: 'test',
         src: 'test.js',
-        event: { on: ['update'], includeDrafts: false, resource },
+        event: {on: ['update'], includeDrafts: false, resource},
       })
       expect(fn.event.includeDrafts).toEqual(false)
     })
@@ -164,7 +164,7 @@ describe('defineMediaLibraryAssetFunction', () => {
       const fn = fns.defineMediaLibraryAssetFunction({
         name: 'test',
         src: 'test.js',
-        event: { on: ['update'], resource },
+        event: {on: ['update'], resource},
         project: 'projectId',
       })
       expect(fn.project).toEqual('projectId')
@@ -177,10 +177,10 @@ describe('defineMediaLibraryAssetFunction', () => {
     })
 
     test('should throw an error if validateMediaLibraryAssetFunction returns an error', () => {
-      const spy = vi.spyOn(index, 'validateMediaLibraryAssetFunction').mockImplementation(() => [{ type: 'test', message: 'this is a test' }])
+      const spy = vi.spyOn(index, 'validateMediaLibraryAssetFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
       expect(() =>
         defineBlueprintForResource(
-          fns.defineMediaLibraryAssetFunction({ name: 'test', event: { on: ['publish'], resource: { type: 'media-library', id: 'ml1234' } } }),
+          fns.defineMediaLibraryAssetFunction({name: 'test', event: {on: ['publish'], resource: {type: 'media-library', id: 'ml1234'}}}),
         ),
       ).toThrow('this is a test')
 
@@ -192,95 +192,95 @@ describe('defineMediaLibraryAssetFunction', () => {
 describe('defineScheduledFunction', () => {
   describe('happy paths', () => {
     test('should create a scheduled event with explicit cron fields', () => {
-      const event = { minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*' }
+      const event = {minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'}
       const fn = fns.defineScheduledFunction({
         name: 'test',
         event,
       })
-      expect(fn.event).toEqual({ minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*' })
+      expect(fn.event).toEqual({minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'})
     })
 
     test('should normalize expression to explicit cron fields', () => {
-      const event = { expression: '* * * * *' }
+      const event = {expression: '* * * * *'}
       const fn = fns.defineScheduledFunction({
         name: 'test',
         event,
       })
-      expect(fn.event).toEqual({ minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*' })
+      expect(fn.event).toEqual({minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'})
     })
 
     test('should create a scheduled function with optional timezone', () => {
       const fn = fns.defineScheduledFunction({
         name: 'test',
-        event: { expression: '* * * * *' },
+        event: {expression: '* * * * *'},
         timezone: 'America/New_York',
       })
       expect(fn.timezone).toEqual('America/New_York')
-      expect(fn.event).toEqual({ minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*' })
+      expect(fn.event).toEqual({minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'})
     })
 
     test('should parse natural language expression to explicit cron fields', () => {
       const fn = fns.defineScheduledFunction({
         name: 'test',
-        event: { expression: 'every day at 9am' },
+        event: {expression: 'every day at 9am'},
       })
-      expect(fn.event).toEqual({ minute: '0', hour: '9', dayOfMonth: '*', month: '*', dayOfWeek: '*' })
+      expect(fn.event).toEqual({minute: '0', hour: '9', dayOfMonth: '*', month: '*', dayOfWeek: '*'})
     })
 
     test('should normalize cron expression to explicit fields', () => {
       const fn = fns.defineScheduledFunction({
         name: 'test',
-        event: { expression: '0 9 * * 1-5' },
+        event: {expression: '0 9 * * 1-5'},
       })
-      expect(fn.event).toEqual({ minute: '0', hour: '9', dayOfMonth: '*', month: '*', dayOfWeek: '1-5' })
+      expect(fn.event).toEqual({minute: '0', hour: '9', dayOfMonth: '*', month: '*', dayOfWeek: '1-5'})
     })
 
     test('should parse weekday natural language', () => {
       const fn = fns.defineScheduledFunction({
         name: 'test',
-        event: { expression: 'weekdays at 8am' },
+        event: {expression: 'weekdays at 8am'},
       })
-      expect(fn.event).toEqual({ minute: '0', hour: '8', dayOfMonth: '*', month: '*', dayOfWeek: '1-5' })
+      expect(fn.event).toEqual({minute: '0', hour: '8', dayOfMonth: '*', month: '*', dayOfWeek: '1-5'})
     })
 
     test('should parse specific weekday with time', () => {
       const fn = fns.defineScheduledFunction({
         name: 'test',
-        event: { expression: 'fridays at 9am' },
+        event: {expression: 'fridays at 9am'},
       })
-      expect(fn.event).toEqual({ minute: '0', hour: '9', dayOfMonth: '*', month: '*', dayOfWeek: '5' })
+      expect(fn.event).toEqual({minute: '0', hour: '9', dayOfMonth: '*', month: '*', dayOfWeek: '5'})
     })
 
     test('should parse time of day period', () => {
       const fn = fns.defineScheduledFunction({
         name: 'test',
-        event: { expression: 'fridays in the evening' },
+        event: {expression: 'fridays in the evening'},
       })
-      expect(fn.event).toEqual({ minute: '0', hour: '18', dayOfMonth: '*', month: '*', dayOfWeek: '5' })
+      expect(fn.event).toEqual({minute: '0', hour: '18', dayOfMonth: '*', month: '*', dayOfWeek: '5'})
     })
 
     test('should parse multiple weekdays', () => {
       const fn = fns.defineScheduledFunction({
         name: 'test',
-        event: { expression: 'mon, wed, fri at 9am' },
+        event: {expression: 'mon, wed, fri at 9am'},
       })
-      expect(fn.event).toEqual({ minute: '0', hour: '9', dayOfMonth: '*', month: '*', dayOfWeek: '1,3,5' })
+      expect(fn.event).toEqual({minute: '0', hour: '9', dayOfMonth: '*', month: '*', dayOfWeek: '1,3,5'})
     })
 
     test('should parse interval schedules', () => {
       const fn = fns.defineScheduledFunction({
         name: 'test',
-        event: { expression: 'every 15 minutes' },
+        event: {expression: 'every 15 minutes'},
       })
-      expect(fn.event).toEqual({ minute: '*/15', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*' })
+      expect(fn.event).toEqual({minute: '*/15', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'})
     })
 
     test('deprecated method defineScheduleFunction should work', () => {
       const fn = fns.defineScheduleFunction({
         name: 'test',
-        event: { expression: 'every 15 minutes' },
+        event: {expression: 'every 15 minutes'},
       })
-      expect(fn.event).toEqual({ minute: '*/15', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*' })
+      expect(fn.event).toEqual({minute: '*/15', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'})
     })
   })
 
@@ -290,10 +290,10 @@ describe('defineScheduledFunction', () => {
     })
 
     test('should throw an error if validateScheduledFunction returns an error', () => {
-      const spy = vi.spyOn(index, 'validateScheduledFunction').mockImplementation(() => [{ type: 'test', message: 'this is a test' }])
+      const spy = vi.spyOn(index, 'validateScheduledFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
       expect(() =>
         defineBlueprintForResource(
-          fns.defineScheduledFunction({ name: 'test', event: { minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*' } }),
+          fns.defineScheduledFunction({name: 'test', event: {minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'}}),
         ),
       ).toThrow('this is a test')
 
@@ -314,9 +314,9 @@ describe('defineWorkflow', () => {
     test('should create a workflow with an event', () => {
       const fn = fns.defineWorkflow({
         name: 'test',
-        event: { type: 'document', on: ['create'], filter: "_type == 'article'" },
+        event: {type: 'document', on: ['create'], filter: "_type == 'article'"},
       })
-      expect(fn.event).toEqual({ type: 'document', on: ['create'], filter: "_type == 'article'" })
+      expect(fn.event).toEqual({type: 'document', on: ['create'], filter: "_type == 'article'"})
     })
 
     test('should create a workflow function with optional concurrency', () => {
@@ -354,10 +354,10 @@ describe('defineWorkflow', () => {
       })
 
       test('should throw an error if validateWorkflowFunction returns an error', () => {
-        const spy = vi.spyOn(index, 'validateWorkflowFunction').mockImplementation(() => [{ type: 'test', message: 'this is a test' }])
+        const spy = vi.spyOn(index, 'validateWorkflowFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
         expect(() =>
           defineBlueprintForResource(
-            fns.defineWorkflow({ name: 'test', event: { type: 'document', on: ['create'], filter: "_type == 'article'" } }),
+            fns.defineWorkflow({name: 'test', event: {type: 'document', on: ['create'], filter: "_type == 'article'"}}),
           ),
         ).toThrow('this is a test')
 
@@ -369,14 +369,14 @@ describe('defineWorkflow', () => {
   describe('defineQueueFunction', () => {
     describe('happy paths', () => {
       test('should create a queue function without an event', () => {
-        const fn = fns.defineQueueFunction({ name: 'test' })
+        const fn = fns.defineQueueFunction({name: 'test'})
         expect(fn.type).toEqual('sanity.function.queue')
         expect(fn).not.toHaveProperty('event')
       })
 
       test('should pass through a document event', () => {
-        const event: BlueprintFunctionResourceEvent = { type: 'document', on: ['publish'], filter: "_type == 'post'" }
-        const fn = fns.defineQueueFunction({ name: 'test', event })
+        const event: BlueprintFunctionResourceEvent = {type: 'document', on: ['publish'], filter: "_type == 'post'"}
+        const fn = fns.defineQueueFunction({name: 'test', event})
         expect(fn.event).toEqual(event)
       })
 
@@ -384,28 +384,28 @@ describe('defineWorkflow', () => {
         const event: BlueprintFunctionResourceEvent = {
           type: 'media-library',
           on: ['create'],
-          resource: { type: 'media-library', id: 'my-media-library-id' },
+          resource: {type: 'media-library', id: 'my-media-library-id'},
         }
-        const fn = fns.defineQueueFunction({ name: 'test', event })
+        const fn = fns.defineQueueFunction({name: 'test', event})
         expect(fn.event).toEqual(event)
       })
 
       test('should pass through a cron event', () => {
-        const event: BlueprintFunctionResourceEvent = { type: 'cron', minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*' }
-        const fn = fns.defineQueueFunction({ name: 'test', event })
+        const event: BlueprintFunctionResourceEvent = {type: 'cron', minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'}
+        const fn = fns.defineQueueFunction({name: 'test', event})
         expect(fn.event).toEqual(event)
       })
 
       test('should pass through a sync-tag-invalidate event', () => {
-        const event: BlueprintFunctionResourceEvent = { type: 'sync-tag-invalidate', resource: { type: 'dataset', id: 'myProj.myDataset' } }
-        const fn = fns.defineQueueFunction({ name: 'test', event })
+        const event: BlueprintFunctionResourceEvent = {type: 'sync-tag-invalidate', resource: {type: 'dataset', id: 'myProj.myDataset'}}
+        const fn = fns.defineQueueFunction({name: 'test', event})
         expect(fn.event).toEqual(event)
       })
 
       test('should pass through concurrency, fifo and dlq alongside an event', () => {
-        const event: BlueprintFunctionResourceEvent = { type: 'document', on: ['publish'] }
-        const fn = fns.defineQueueFunction({ name: 'test', event, concurrency: 5, fifo: false, dlq: false })
-        expect(fn).toMatchObject({ event, concurrency: 5, fifo: false, dlq: false })
+        const event: BlueprintFunctionResourceEvent = {type: 'document', on: ['publish']}
+        const fn = fns.defineQueueFunction({name: 'test', event, concurrency: 5, fifo: false, dlq: false})
+        expect(fn).toMatchObject({event, concurrency: 5, fifo: false, dlq: false})
       })
     })
 
@@ -415,10 +415,10 @@ describe('defineWorkflow', () => {
       })
 
       test('should throw an error if validateQueueFunction returns an error', () => {
-        const spy = vi.spyOn(index, 'validateQueueFunction').mockImplementation(() => [{ type: 'test', message: 'this is a test' }])
-        expect(() => defineBlueprintForResource(fns.defineQueueFunction({ name: 'test', event: { type: 'document', on: ['publish'] } }))).toThrow(
-          'this is a test',
-        )
+        const spy = vi.spyOn(index, 'validateQueueFunction').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
+        expect(() =>
+          defineBlueprintForResource(fns.defineQueueFunction({name: 'test', event: {type: 'document', on: ['publish']}})),
+        ).toThrow('this is a test')
 
         expect(spy).toHaveBeenCalledOnce()
       })

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -802,7 +802,7 @@ describe('validateQueueFunction', () => {
       })
       expect(errors).toContainEqual({
         type: 'invalid_value',
-        message: '`event.type` must be one of "document", "media-library", "cron", "sync-tag-invalidate"',
+        message: '`event.type` must be either `cron`, `document`, `sync-tag-invalidate`, or `media-library`',
       })
     })
     test('should surface errors from the delegated event validator', () => {
@@ -952,7 +952,7 @@ describe('validateWorkflowFunction', () => {
       })
       expect(errors).toContainEqual({
         type: 'invalid_value',
-        message: '`event.type` must be either `document`, `sync-tag-invalidate`, or `media-library`',
+        message: '`event.type` must be either `cron`, `document`, `sync-tag-invalidate`, or `media-library`',
       })
     })
 

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -763,6 +763,14 @@ describe('validateQueueFunction', () => {
       })
       expect(errors).toStrictEqual([])
     })
+    test('should accept a queue function with a sync-tag-invalidate event and no resource', () => {
+      const errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {type: 'sync-tag-invalidate'},
+      })
+      expect(errors).toStrictEqual([])
+    })
   })
   describe('sad paths', () => {
     test('should return an error if the type is not `sanity.function.queue`', () => {

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -731,6 +731,38 @@ describe('validateQueueFunction', () => {
       })
       expect(errors).toStrictEqual([])
     })
+    test('should accept a queue function with a document event', () => {
+      const errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {type: 'document', on: ['publish'], filter: "_type == 'post'"},
+      })
+      expect(errors).toStrictEqual([])
+    })
+    test('should accept a queue function with a media-library event', () => {
+      const errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {type: 'media-library', on: ['create'], resource: {type: 'media-library', id: 'my-media-library-id'}},
+      })
+      expect(errors).toStrictEqual([])
+    })
+    test('should accept a queue function with a cron event', () => {
+      const errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {type: 'cron', minute: '*', hour: '*', dayOfMonth: '*', month: '*', dayOfWeek: '*'},
+      })
+      expect(errors).toStrictEqual([])
+    })
+    test('should accept a queue function with a sync-tag-invalidate event', () => {
+      const errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {type: 'sync-tag-invalidate', resource: {type: 'dataset', id: 'myProj.myDataset'}},
+      })
+      expect(errors).toStrictEqual([])
+    })
   })
   describe('sad paths', () => {
     test('should return an error if the type is not `sanity.function.queue`', () => {
@@ -738,6 +770,50 @@ describe('validateQueueFunction', () => {
       expect(errors).toContainEqual({
         type: 'invalid_value',
         message: '`type` must be `sanity.function.queue`',
+      })
+    })
+    test('should return an error if event is not an object', () => {
+      const errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: 'publish',
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_type',
+        message: '`event` must be an object',
+      })
+    })
+    test('should return an error if event.type is missing', () => {
+      const errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {on: ['publish']},
+      })
+      expect(errors).toContainEqual({
+        type: 'missing_parameter',
+        message: '`event.type` is required',
+      })
+    })
+    test('should return an error if event.type is unknown', () => {
+      const errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {type: 'nope'},
+      })
+      expect(errors).toContainEqual({
+        type: 'invalid_value',
+        message: '`event.type` must be one of "document", "media-library", "cron", "sync-tag-invalidate"',
+      })
+    })
+    test('should surface errors from the delegated event validator', () => {
+      const errors = functions.validateQueueFunction({
+        name: 'test',
+        type: 'sanity.function.queue',
+        event: {type: 'media-library', on: ['create']},
+      })
+      expect(errors).toContainEqual({
+        type: 'missing_parameter',
+        message: '`resource` is required for a media library function',
       })
     })
     test('should return an error if concurrency is invalid', () => {

--- a/test/unit/validation/functions.test.ts
+++ b/test/unit/validation/functions.test.ts
@@ -715,7 +715,9 @@ describe('validateQueueFunction', () => {
       const errors = functions.validateQueueFunction({
         name: 'test',
         type: 'sanity.function.queue',
-        event: {concurrency: 1, fifo: true, dlq: true},
+        concurrency: 1,
+        fifo: true,
+        dlq: true,
       })
       expect(errors).toStrictEqual([])
     })
@@ -723,7 +725,9 @@ describe('validateQueueFunction', () => {
       const errors = functions.validateQueueFunction({
         name: 'test',
         type: 'sanity.function.queue',
-        event: {concurrency: 5, fifo: false, dlq: false},
+        concurrency: 5,
+        fifo: false,
+        dlq: false,
       })
       expect(errors).toStrictEqual([])
     })
@@ -736,73 +740,87 @@ describe('validateQueueFunction', () => {
         message: '`type` must be `sanity.function.queue`',
       })
     })
-    test('should return an error if event.concurrency is invalid', () => {
+    test('should return an error if concurrency is invalid', () => {
       let errors = functions.validateQueueFunction({
         name: 'test',
         type: 'sanity.function.queue',
-        event: {fifo: true, dlq: true},
+        concurrency: {},
+        fifo: true,
+        dlq: true,
       })
       expect(errors).toContainEqual({
         type: 'invalid_type',
-        message: '`event.concurrency` must be a number',
+        message: '`concurrency` must be a number',
       })
       errors = functions.validateQueueFunction({
         name: 'test',
         type: 'sanity.function.queue',
-        event: {concurrency: 'five', fifo: true, dlq: true},
+        concurrency: 'five',
+        fifo: true,
+        dlq: true,
       })
       expect(errors).toContainEqual({
         type: 'invalid_type',
-        message: '`event.concurrency` must be a number',
+        message: '`concurrency` must be a number',
       })
       errors = functions.validateQueueFunction({
         name: 'test',
         type: 'sanity.function.queue',
-        event: {concurrency: 0, fifo: true, dlq: true},
+        concurrency: 0,
+        fifo: true,
+        dlq: true,
       })
       expect(errors).toContainEqual({
         type: 'invalid_type',
-        message: '`event.concurrency` must be at least 1',
+        message: '`concurrency` must be at least 1',
       })
     })
-    test('should return an error if event.fifo is invalid', () => {
+    test('should return an error if fifo is invalid', () => {
       let errors = functions.validateQueueFunction({
         name: 'test',
         type: 'sanity.function.queue',
-        event: {concurrency: 1, dlq: true},
+        concurrency: 1,
+        dlq: true,
+        fifo: 'true',
       })
       expect(errors).toContainEqual({
         type: 'invalid_type',
-        message: '`event.fifo` must be a boolean',
+        message: '`fifo` must be a boolean',
       })
       errors = functions.validateQueueFunction({
         name: 'test',
         type: 'sanity.function.queue',
-        event: {concurrency: 1, fifo: 'yes', dlq: true},
+        concurrency: 1,
+        fifo: 'yes',
+        dlq: true,
       })
       expect(errors).toContainEqual({
         type: 'invalid_type',
-        message: '`event.fifo` must be a boolean',
+        message: '`fifo` must be a boolean',
       })
     })
-    test('should return an error if event.dlq is invalid', () => {
+    test('should return an error if dlq is invalid', () => {
       let errors = functions.validateQueueFunction({
         name: 'test',
         type: 'sanity.function.queue',
-        event: {concurrency: 1, fifo: true},
+        concurrency: 1,
+        dlq: 'true',
+        fifo: true,
       })
       expect(errors).toContainEqual({
         type: 'invalid_type',
-        message: '`event.dlq` must be a boolean',
+        message: '`dlq` must be a boolean',
       })
       errors = functions.validateQueueFunction({
         name: 'test',
         type: 'sanity.function.queue',
-        event: {concurrency: 1, fifo: true, dlq: 'yes'},
+        concurrency: 1,
+        fifo: true,
+        dlq: 'yes',
       })
       expect(errors).toContainEqual({
         type: 'invalid_type',
-        message: '`event.dlq` must be a boolean',
+        message: '`dlq` must be a boolean',
       })
     })
   })


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

I'm refining the `defineQueueFunction` helper to put the three properties concurrency, fifo and dlq at the root of the definition and not in a queue property. Note: I will be adding more properties soonish.

Also, I'm changing this so that the queue can be triggered by any type of event, doc, media, etc.

Finally, I'm re-using `BlueprintFunctionResourceEvent` in both the queue and workflow definitions.

See [RUN-1505](https://linear.app/sanity/issue/RUN-1505/update-definequeuefunction-and-definefunction-with-correct-a-rule-that)

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Make sure my optional event changes to queue and workflow make sense.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

New automated tests added.