### PR TITLE
fix(defineStudio): defaults pass validation

### DIFF
--- a/src/definers/studios.ts
+++ b/src/definers/studios.ts
@@ -8,6 +8,7 @@ import {runValidation} from '../utils/validation.js'
  * ```ts
  * defineStudio({
  *   name: 'my-studio',
+ *   project: 'my-project-id',
  *   src: 'studios/my-studio',
  *   autoUpdates: {
  *     enabled: true
@@ -23,13 +24,16 @@ import {runValidation} from '../utils/validation.js'
  * @hidden
  */
 export function defineStudio(config: BlueprintStudioConfig): BlueprintStudioResource {
+  const autoUpdates: BlueprintStudioResource['autoUpdates'] = {enabled: config.autoUpdates?.enabled ?? true}
+  if (config.autoUpdates?.version !== undefined) {
+    autoUpdates.version = config.autoUpdates.version
+  }
+
   const studioResource: BlueprintStudioResource = {
-    title: config.name,
-    autoUpdates: {
-      enabled: config.autoUpdates?.enabled ?? true,
-      version: config.autoUpdates?.version,
-    },
     ...config,
+    slug: config.slug || config.name,
+    title: config.title || config.name,
+    autoUpdates,
     type: 'sanity.studio',
   }
 

--- a/src/types/studios.ts
+++ b/src/types/studios.ts
@@ -89,16 +89,19 @@ export interface BlueprintStudioResource extends BlueprintResource<BlueprintProj
  * @interface
  * @hidden
  */
-export interface BlueprintStudioConfig extends Omit<BlueprintStudioResource, 'type' | 'title' | 'autoUpdates'> {
+export interface BlueprintStudioConfig extends Omit<BlueprintStudioResource, 'type' | 'slug' | 'title' | 'autoUpdates'> {
+  /** The slug to be used in the studio hostname. Defaults to the name of the resource. */
+  slug?: string
+
   /** Title for the studio. Defaults to the name of the resource. */
   title?: string
 
   /**
-   * Auto update settings for the studio.
+   * Auto update settings for the studio. Defaults to `{enabled: true}`.
    */
   autoUpdates?: {
-    /** Whether auto updates are enabled for the studio. Defaults to true if autoUpdates is not provided. */
-    enabled: boolean
+    /** Whether auto updates are enabled for the studio. Defaults to true. */
+    enabled?: boolean
 
     /** What "version"/"channel" to use for auto updates */
     version?: string // 'next', 'stable', 'latest' or a semantic version (e.g., "1.2.3", "2.0.0-beta.1")

--- a/src/types/studios.ts
+++ b/src/types/studios.ts
@@ -39,10 +39,14 @@ export interface BlueprintStudioResource extends BlueprintResource<BlueprintProj
   /** The relative location of the studio source code. */
   src: string
 
-  /** The project ID of the project that contains your Studio. */
-  project: string
+  /**
+   * The project ID of the project that contains your Studio.
+   *
+   * The `project` attribute must be defined if your blueprint is scoped to an organization.
+   */
+  project?: string
 
-  /** The slug to be used in the studio hostname. */
+  /** The slug to be used in the studio hostname. Must match `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`. */
   slug: string
 
   /** Title for the studio. */
@@ -90,7 +94,12 @@ export interface BlueprintStudioResource extends BlueprintResource<BlueprintProj
  * @hidden
  */
 export interface BlueprintStudioConfig extends Omit<BlueprintStudioResource, 'type' | 'slug' | 'title' | 'autoUpdates'> {
-  /** The slug to be used in the studio hostname. Defaults to the name of the resource. */
+  /**
+   * The slug to be used in the studio hostname. Must match `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`.
+   *
+   * Defaults to the name of the resource.
+   * Set `slug` explicitly if the resource name is not a valid hostname.
+   */
   slug?: string
 
   /** Title for the studio. Defaults to the name of the resource. */

--- a/src/validation/studios.ts
+++ b/src/validation/studios.ts
@@ -1,6 +1,10 @@
 import type {BlueprintError} from '../types/errors.js'
 import {APPLICATION_VISIBILITIES} from '../types/studios.js'
+import {isReference} from '../utils/validation.js'
 import {validateResource} from './resources.js'
+
+/** hostname validity pattern */
+const STUDIO_SLUG_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
 
 /**
  * Validates that the given resource is a valid Studio.
@@ -25,16 +29,18 @@ export function validateStudio(resource: unknown): BlueprintError[] {
     errors.push({type: 'invalid_type', message: 'Studio src must be a string'})
   }
 
-  if (!('project' in resource) || !resource.project) {
-    errors.push({type: 'missing_parameter', message: 'Studio project is required'})
-  } else if (typeof resource.project !== 'string') {
-    errors.push({type: 'invalid_type', message: 'Studio project must be a string'})
+  if ('project' in resource) {
+    if (typeof resource.project !== 'string') {
+      errors.push({type: 'invalid_type', message: 'Studio project must be a string'})
+    }
   }
 
   if (!('slug' in resource) || !resource.slug) {
     errors.push({type: 'missing_parameter', message: 'Studio slug is required'})
   } else if (typeof resource.slug !== 'string') {
     errors.push({type: 'invalid_type', message: 'Studio slug must be a string'})
+  } else if (!isReference(resource.slug) && !STUDIO_SLUG_PATTERN.test(resource.slug)) {
+    errors.push({type: 'invalid_format', message: `Studio slug must match pattern: ${STUDIO_SLUG_PATTERN.source}`})
   }
 
   if (!('title' in resource) || !resource.title) {

--- a/test/unit/definers/studios.test.ts
+++ b/test/unit/definers/studios.test.ts
@@ -119,6 +119,20 @@ describe('defineStudio', () => {
     expect(index.validateStudio(studioResource)).toStrictEqual([])
   })
 
+  test('should not accept a name that is not a valid hostname label as a slug', () => {
+    const studioResource = studios.defineStudio({
+      name: 'My Studio',
+      src: 'studios/my-studio',
+      project: 'abcd1234',
+    })
+
+    expect(studioResource.slug).toStrictEqual('My Studio')
+    expect(index.validateStudio(studioResource)).toContainEqual({
+      type: 'invalid_format',
+      message: 'Studio slug must match pattern: ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$',
+    })
+  })
+
   test('should accept a valid configuration with a lifecycle', () => {
     const studioResource = studios.defineStudio({
       name: 'studio-name',

--- a/test/unit/definers/studios.test.ts
+++ b/test/unit/definers/studios.test.ts
@@ -64,19 +64,17 @@ describe('defineStudio', () => {
     expect(studioResource.title).toStrictEqual('studio-name')
   })
 
-  test('should default the autoUpdates to enabled with undefined version', () => {
+  test('should default the slug to the name', () => {
     const studioResource = studios.defineStudio({
       name: 'studio-name',
       src: 'studios/my-studio',
       project: 'abcd1234',
-      slug: 'my-studio',
     })
 
-    expect(studioResource.autoUpdates.enabled).toStrictEqual(true)
-    expect(studioResource.autoUpdates.version).toBeUndefined()
+    expect(studioResource.slug).toStrictEqual('studio-name')
   })
 
-  test('should default the autoUpdates to enabled with undefined version', () => {
+  test('should default the autoUpdates to enabled and omit the version', () => {
     const studioResource = studios.defineStudio({
       name: 'studio-name',
       src: 'studios/my-studio',
@@ -84,8 +82,41 @@ describe('defineStudio', () => {
       slug: 'my-studio',
     })
 
-    expect(studioResource.autoUpdates.enabled).toStrictEqual(true)
-    expect(studioResource.autoUpdates.version).toBeUndefined()
+    expect(studioResource.autoUpdates).toStrictEqual({enabled: true})
+  })
+
+  test('should omit the version when autoUpdates is provided without one', () => {
+    const studioResource = studios.defineStudio({
+      name: 'studio-name',
+      src: 'studios/my-studio',
+      project: 'abcd1234',
+      slug: 'my-studio',
+      autoUpdates: {enabled: false},
+    })
+
+    expect(studioResource.autoUpdates).toStrictEqual({enabled: false})
+  })
+
+  test('should keep an explicit autoUpdates version', () => {
+    const studioResource = studios.defineStudio({
+      name: 'studio-name',
+      src: 'studios/my-studio',
+      project: 'abcd1234',
+      slug: 'my-studio',
+      autoUpdates: {version: '^4.0.0'},
+    })
+
+    expect(studioResource.autoUpdates).toStrictEqual({enabled: true, version: '^4.0.0'})
+  })
+
+  test('should produce a valid resource from a minimal config', () => {
+    const studioResource = studios.defineStudio({
+      name: 'studio-name',
+      src: 'studios/my-studio',
+      project: 'abcd1234',
+    })
+
+    expect(index.validateStudio(studioResource)).toStrictEqual([])
   })
 
   test('should accept a valid configuration with a lifecycle', () => {

--- a/test/unit/validation/studios.test.ts
+++ b/test/unit/validation/studios.test.ts
@@ -84,9 +84,37 @@ describe('validateStudio', () => {
     expect(errors).toContainEqual({type: 'invalid_type', message: 'Studio sourceMap must be a boolean'})
   })
 
+  test.each([
+    'My Studio',
+    'my_studio',
+    'My-Studio',
+    '-my-studio',
+    'my-studio-',
+    'café',
+  ])('should return an error if slug is not a valid hostname label: %s', (slug) => {
+    const errors = validateStudio({...validStudio, slug})
+    expect(errors).toContainEqual({type: 'invalid_format', message: 'Studio slug must match pattern: ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'})
+  })
+
+  test.each(['my-studio', 'studio', 's', '2024', 'my-studio-2'])('should accept a valid slug: %s', (slug) => {
+    const errors = validateStudio({...validStudio, slug})
+    expect(errors, JSON.stringify(errors)).toHaveLength(0)
+  })
+
+  test('should not check the slug pattern for a reference', () => {
+    const errors = validateStudio({...validStudio, slug: '$.parameters.studioSlug'})
+    expect(errors, JSON.stringify(errors)).toHaveLength(0)
+  })
+
   test('should return an error if project is not a string', () => {
     const errors = validateStudio({...validStudio, project: 1})
     expect(errors).toContainEqual({type: 'invalid_type', message: 'Studio project must be a string'})
+  })
+
+  test('should accept a configuration without a project', () => {
+    const {project: _project, ...noProject} = validStudio
+    const errors = validateStudio(noProject)
+    expect(errors, JSON.stringify(errors)).toHaveLength(0)
   })
 
   test('should accept a valid configuration', () => {


### PR DESCRIPTION
as of now, `defineStudio({name, project, src})` fails its own validation

---

## changes

- default `slug` to name (was required, undefaulted)
  - validate slug as valid hostname, skipped for blueprint references
- omit `autoUpdates.version` when `undefined` 
  - previously it wrote the key as undefined
- Config type: slug, title, autoUpdates, and autoUpdates.enabled _optional_; 
  - all still **required** on the resource type
- `project` optional on the resource type; 
  - matching datasets/CORS/functions