### PR TITLE
fix: dataset visibility

### DIFF
--- a/src/definers/datasets.ts
+++ b/src/definers/datasets.ts
@@ -8,7 +8,7 @@ import {runValidation} from '../utils/validation.js'
  * defineDataset({
  *   name: 'staging',
  *   datasetName: 'staging-v2',
- *   aclMode: 'private',
+ *   visibility: 'private',
  *   project: 'my-project-id',
  *   lifecycle: {deletionPolicy: 'protect'},
  * })
@@ -32,12 +32,14 @@ import {runValidation} from '../utils/validation.js'
  * @returns The dataset resource
  */
 export function defineDataset(parameters: BlueprintDatasetConfig): BlueprintDatasetResource {
-  // default dataset name
+  // default dataset name and acl mode
   const datasetName = parameters.datasetName || parameters.name
+  const aclMode = parameters.aclMode || parameters.visibility
 
   const datasetResource: BlueprintDatasetResource = {
     ...parameters,
     datasetName,
+    aclMode,
     type: 'sanity.project.dataset',
   }
 

--- a/src/types/datasets.ts
+++ b/src/types/datasets.ts
@@ -21,8 +21,13 @@ export interface BlueprintDatasetResource extends BlueprintResource<BlueprintPro
   datasetName: string
   /** The dataset description */
   description?: string
-  /** The ACL mode to set for the new dataset. Defaults to public. */
+  /**
+   * The ACL mode to set for the dataset. Defaults to public.
+   * @hidden
+   */
   aclMode?: AclMode
+  /** The visibility to set for the dataset. Defaults to public. */
+  visibility?: AclMode
 
   /**
    * The project ID of the project that contains your Dataset.

--- a/test/unit/definers/dataset.test.ts
+++ b/test/unit/definers/dataset.test.ts
@@ -28,6 +28,16 @@ describe('defineDataset', () => {
     expect(datasetResource.description).toStrictEqual('valid dataset')
   })
 
+  test('should accept visibility and set the aclMode', () => {
+    const datasetResource = datasets.defineDataset({
+      name: 'dataset-name',
+      visibility: 'private',
+    })
+
+    expect(datasetResource.type).toStrictEqual('sanity.project.dataset')
+    expect(datasetResource.aclMode).toStrictEqual('private')
+  })
+
   test('should accept a valid configuration with a lifecycle', () => {
     const datasetResource = datasets.defineDataset({
       name: 'dataset-name',


### PR DESCRIPTION
### Description

Add a new property to dataset config called `visibility` to align with terminology used in other parts of Sanity.

### Testing

Added a new test to ensure proper defaulting
