### PR TITLE
fix: restore default for dataset visibility

### DIFF
--- a/src/definers/datasets.ts
+++ b/src/definers/datasets.ts
@@ -34,7 +34,7 @@ import {runValidation} from '../utils/validation.js'
 export function defineDataset(parameters: BlueprintDatasetConfig): BlueprintDatasetResource {
   // default dataset name and acl mode
   const datasetName = parameters.datasetName || parameters.name
-  const aclMode = parameters.aclMode || parameters.visibility
+  const aclMode = parameters.aclMode || parameters.visibility || 'public'
 
   const datasetResource: BlueprintDatasetResource = {
     ...parameters,

--- a/src/types/datasets.ts
+++ b/src/types/datasets.ts
@@ -23,11 +23,8 @@ export interface BlueprintDatasetResource extends BlueprintResource<BlueprintPro
   description?: string
   /**
    * The ACL mode to set for the dataset. Defaults to public.
-   * @hidden
    */
-  aclMode?: AclMode
-  /** The visibility to set for the dataset. Defaults to public. */
-  visibility?: AclMode
+  aclMode: AclMode
 
   /**
    * The project ID of the project that contains your Dataset.
@@ -45,10 +42,17 @@ export interface BlueprintDatasetResource extends BlueprintResource<BlueprintPro
  * @category Resource Types
  * @interface
  */
-export type BlueprintDatasetConfig = Omit<BlueprintDatasetResource, 'type' | 'datasetName'> & {
+export type BlueprintDatasetConfig = Omit<BlueprintDatasetResource, 'type' | 'datasetName' | 'aclMode'> & {
   /**
    * The name of the dataset. Must be unique within a project.
    * @defaultValue The `name` of the resource
    */
   datasetName?: string
+  /**
+   * The ACL mode to set for the dataset. Defaults to public.
+   * @hidden
+   */
+  aclMode?: AclMode
+  /** The visibility to set for the dataset. Defaults to public. */
+  visibility?: AclMode
 }

--- a/test/unit/definers/dataset.test.ts
+++ b/test/unit/definers/dataset.test.ts
@@ -28,6 +28,15 @@ describe('defineDataset', () => {
     expect(datasetResource.description).toStrictEqual('valid dataset')
   })
 
+  test('should set a default aclMode', () => {
+    const datasetResource = datasets.defineDataset({
+      name: 'dataset-name',
+    })
+
+    expect(datasetResource.type).toStrictEqual('sanity.project.dataset')
+    expect(datasetResource.aclMode).toStrictEqual('public')
+  })
+
   test('should accept visibility and set the aclMode', () => {
     const datasetResource = datasets.defineDataset({
       name: 'dataset-name',


### PR DESCRIPTION
### Description

When adding visibility, I forgot to include the default aclMode. Also updated the wrong type. Both issues are fixed in this PR.

### Testing

Added a test to verify the default
