### PR TITLE
feat: EDEX-1732 add defineWorkflows definer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ import {
   defineDocumentWebhook,
   defineRobotToken,
   defineRole,
-  defineWorkflow,
 } from '@sanity/blueprints'
 
 export default defineBlueprint({
@@ -74,5 +73,6 @@ export default defineBlueprint({
 | `defineDocumentWebhook` β | Webhook triggered by document changes |
 | `defineRole` β | Custom role with permissions |
 | `defineRobotToken` β | Robot token for automated access |
+| `defineWorkflows` β | Editorial Workflows definitions deployed as one resource |
 
 Each definer validates its input at call time and returns a typed resource object. See the [reference docs](https://reference.sanity.io/_sanity/blueprints) for full configuration details and additional resource types.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ export default defineBlueprint({
 | `defineDocumentWebhook` β | Webhook triggered by document changes |
 | `defineRole` β | Custom role with permissions |
 | `defineRobotToken` β | Robot token for automated access |
-| `defineWorkflows` β | Editorial Workflows definitions deployed as one resource |
+| `defineWorkflows` β | Declares an Editorial Workflows deployment as one resource |
 
 Each definer validates its input at call time and returns a typed resource object. See the [reference docs](https://reference.sanity.io/_sanity/blueprints) for full configuration details and additional resource types.
+
+> [!WARNING]
+> `defineWorkflows` currently declares and validates a manifest resource only. The Blueprints API has no registered `sanity.workflow` resource
+> provider yet, so `blueprints deploy` cannot deploy this resource and may fail the stack operation. Until the provider is installed and registered,
+> deploy Editorial Workflows definitions with the workflow CLI (`sanity-workflows deploy`).

--- a/src/definers/workflows.ts
+++ b/src/definers/workflows.ts
@@ -16,7 +16,7 @@ import {runValidation} from '../utils/validation.js'
  *   expectedMinReaderModel: 4,
  *   tag: 'production',
  *   workflowResource: {type: 'dataset', id: 'projectId.dataset'},
- *   definitions: [articleReview],
+ *   definitions: [{name: 'article-review'}],
  * })
  * ```
  *

--- a/src/definers/workflows.ts
+++ b/src/definers/workflows.ts
@@ -42,7 +42,10 @@ export function defineWorkflows<Deployment extends BlueprintWorkflowDeployment>(
   const workflowResource: BlueprintWorkflowsResource<Deployment> = {
     name: options?.name ?? `editorial-workflows-${deployment.name}`,
     type: 'sanity.workflow',
-    lifecycle: options?.lifecycle ?? {deletionPolicy: 'retain'},
+    lifecycle: {
+      ...options?.lifecycle,
+      deletionPolicy: options?.lifecycle?.deletionPolicy ?? 'retain',
+    },
     deployment,
   }
 

--- a/src/definers/workflows.ts
+++ b/src/definers/workflows.ts
@@ -9,6 +9,11 @@ import {runValidation} from '../utils/validation.js'
 /**
  * Defines an Editorial Workflows deployment as a Blueprint resource.
  *
+ * @remarks
+ * **Not deployable yet:** this function declares and validates a manifest resource, but the Blueprints API has no registered `sanity.workflow`
+ * resource provider. Adding the resource to a real Blueprint may fail the stack operation. Until the provider is installed and registered, deploy
+ * definitions with the workflow CLI (`sanity-workflows deploy`).
+ *
  * @example
  * ```ts
  * defineWorkflows({
@@ -16,7 +21,12 @@ import {runValidation} from '../utils/validation.js'
  *   expectedMinReaderModel: 4,
  *   tag: 'production',
  *   workflowResource: {type: 'dataset', id: 'projectId.dataset'},
- *   definitions: [{name: 'article-review'}],
+ *   definitions: [{
+ *     name: 'article-review',
+ *     title: 'Article review',
+ *     initialStage: 'draft',
+ *     stages: [{name: 'draft'}],
+ *   }],
  * })
  * ```
  *
@@ -30,7 +40,7 @@ import {runValidation} from '../utils/validation.js'
  * @param deployment The Editorial Workflows deployment
  * @param options The Blueprint resource options
  * @public
- * @beta Deploying Editorial Workflows via Blueprints is experimental. This feature is subject to breaking changes.
+ * @beta Declaring Editorial Workflows resources is experimental. This feature is subject to breaking changes.
  * @category Definers
  * @expandType BlueprintWorkflowDeployment
  * @returns The Editorial Workflows resource

--- a/src/definers/workflows.ts
+++ b/src/definers/workflows.ts
@@ -1,7 +1,7 @@
 import {
   type BlueprintWorkflowDeployment,
+  type BlueprintWorkflowsOptions,
   type BlueprintWorkflowsResource,
-  type DefineWorkflowsOptions,
   validateWorkflows,
 } from '../index.js'
 import {runValidation} from '../utils/validation.js'
@@ -37,7 +37,7 @@ import {runValidation} from '../utils/validation.js'
  */
 export function defineWorkflows<Deployment extends BlueprintWorkflowDeployment>(
   deployment: Deployment,
-  options?: DefineWorkflowsOptions,
+  options?: BlueprintWorkflowsOptions,
 ): BlueprintWorkflowsResource<Deployment> {
   const workflowResource: BlueprintWorkflowsResource<Deployment> = {
     name: options?.name ?? `editorial-workflows-${deployment.name}`,

--- a/src/definers/workflows.ts
+++ b/src/definers/workflows.ts
@@ -1,0 +1,52 @@
+import {
+  type BlueprintWorkflowDeployment,
+  type BlueprintWorkflowsResource,
+  type DefineWorkflowsOptions,
+  validateWorkflows,
+} from '../index.js'
+import {runValidation} from '../utils/validation.js'
+
+/**
+ * Defines an Editorial Workflows deployment as a Blueprint resource.
+ *
+ * @example
+ * ```ts
+ * defineWorkflows({
+ *   name: 'production',
+ *   expectedMinReaderModel: 4,
+ *   tag: 'production',
+ *   workflowResource: {type: 'dataset', id: 'projectId.dataset'},
+ *   definitions: [articleReview],
+ * })
+ * ```
+ *
+ * @example Protected resource
+ * ```ts
+ * defineWorkflows(deployment, {
+ *   name: 'editorial-workflows',
+ *   lifecycle: {deletionPolicy: 'protect'},
+ * })
+ * ```
+ * @param deployment The Editorial Workflows deployment
+ * @param options The Blueprint resource options
+ * @public
+ * @beta Deploying Editorial Workflows via Blueprints is experimental. This feature is subject to breaking changes.
+ * @category Definers
+ * @expandType BlueprintWorkflowDeployment
+ * @returns The Editorial Workflows resource
+ */
+export function defineWorkflows<Deployment extends BlueprintWorkflowDeployment>(
+  deployment: Deployment,
+  options?: DefineWorkflowsOptions,
+): BlueprintWorkflowsResource<Deployment> {
+  const workflowResource: BlueprintWorkflowsResource<Deployment> = {
+    name: options?.name ?? `editorial-workflows-${deployment.name}`,
+    type: 'sanity.workflow',
+    lifecycle: options?.lifecycle ?? {deletionPolicy: 'retain'},
+    deployment,
+  }
+
+  runValidation(() => validateWorkflows(workflowResource), {throwError: true})
+
+  return workflowResource
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export * from './definers/robotTokens.js'
 export * from './definers/roles.js'
 export * from './definers/studios.js'
 export * from './definers/webhooks.js'
+export * from './definers/workflows.js'
 
 // TYPES - base types for all resources
 /**
@@ -47,6 +48,7 @@ export * from './types/robotTokens.js'
 export * from './types/roles.js'
 export * from './types/studios.js'
 export * from './types/webhooks.js'
+export * from './types/workflows.js'
 
 // VALIDATION - validation for all resources
 /**
@@ -64,6 +66,7 @@ export * from './validation/robotTokens.js'
 export * from './validation/roles.js'
 export * from './validation/studios.js'
 export * from './validation/webhooks.js'
+export * from './validation/workflows.js'
 
 // Public BLUEPRINTS INTERNALS - published bucket of misc Blueprint types
 /**

--- a/src/types/workflows.ts
+++ b/src/types/workflows.ts
@@ -1,0 +1,77 @@
+import type {BlueprintResource, BlueprintResourceLifecycle} from '../index.js'
+
+/**
+ * A resource that can store Editorial Workflows data.
+ * @beta This feature is subject to breaking changes.
+ * @category Resource Types
+ * @expand
+ */
+export interface BlueprintWorkflowTarget {
+  type: 'dataset' | 'canvas' | 'media-library' | 'dashboard'
+  id: string
+}
+
+/**
+ * A logical resource handle used by an Editorial Workflows definition.
+ * @beta This feature is subject to breaking changes.
+ * @category Resource Types
+ * @expand
+ */
+export interface BlueprintWorkflowResourceBinding {
+  name: string
+  resource: BlueprintWorkflowTarget
+}
+
+/**
+ * The portion of an Editorial Workflows definition used by Blueprints validation.
+ * @beta This feature is subject to breaking changes.
+ * @category Resource Types
+ * @expand
+ */
+export interface BlueprintWorkflowDefinition {
+  name: string
+}
+
+/**
+ * An Editorial Workflows deployment carried by a Blueprint resource.
+ * @beta This feature is subject to breaking changes.
+ * @category Resource Types
+ */
+export interface BlueprintWorkflowDeployment {
+  name: string
+  expectedMinReaderModel: number
+  tag: string
+  workflowResource: BlueprintWorkflowTarget
+  resourceAliases?: BlueprintWorkflowResourceBinding[]
+  definitions: BlueprintWorkflowDefinition[]
+}
+
+/**
+ * Options for an Editorial Workflows Blueprint resource.
+ * @beta This feature is subject to breaking changes.
+ * @category Resource Types
+ * @interface
+ */
+export interface DefineWorkflowsOptions {
+  /**
+   * The Blueprint resource name.
+   * @defaultValue `editorial-workflows-<deployment name>`
+   */
+  name?: string
+  /**
+   * The Blueprint lifecycle policy.
+   * @defaultValue `{deletionPolicy: 'retain'}`
+   */
+  lifecycle?: BlueprintResourceLifecycle
+}
+
+/**
+ * An Editorial Workflows deployment declared as a Blueprint resource.
+ * @beta This feature is subject to breaking changes.
+ * @category Resource Types
+ */
+export interface BlueprintWorkflowsResource<Deployment extends BlueprintWorkflowDeployment = BlueprintWorkflowDeployment>
+  extends BlueprintResource {
+  type: 'sanity.workflow'
+  deployment: Deployment
+}

--- a/src/types/workflows.ts
+++ b/src/types/workflows.ts
@@ -79,8 +79,10 @@ export interface BlueprintWorkflowDeployment {
  * @beta This feature is subject to breaking changes.
  * @category Resource Types
  */
-export interface BlueprintWorkflowsLifecycle extends BlueprintResourceLifecycle {
+export interface BlueprintWorkflowsLifecycle extends Omit<BlueprintResourceLifecycle, 'deletionPolicy' | 'ownershipAction'> {
   deletionPolicy?: 'retain' | 'protect'
+  /** Ownership actions are unavailable until the resource provider defines stable attach, detach, and reference semantics. */
+  ownershipAction?: never
 }
 
 /**

--- a/src/types/workflows.ts
+++ b/src/types/workflows.ts
@@ -1,13 +1,20 @@
 import type {BlueprintResource, BlueprintResourceLifecycle} from '../index.js'
 
 /**
+ * Resource types that can store Editorial Workflows data.
+ * @beta This feature is subject to breaking changes.
+ * @category Resource Types
+ */
+export const WORKFLOW_TARGET_TYPES = ['dataset', 'canvas', 'media-library', 'dashboard'] as const
+
+/**
  * A resource that can store Editorial Workflows data.
  * @beta This feature is subject to breaking changes.
  * @category Resource Types
  * @expand
  */
 export interface BlueprintWorkflowTarget {
-  type: 'dataset' | 'canvas' | 'media-library' | 'dashboard'
+  type: (typeof WORKFLOW_TARGET_TYPES)[number]
   id: string
 }
 
@@ -59,9 +66,8 @@ export interface BlueprintWorkflowsLifecycle extends BlueprintResourceLifecycle 
  * Options for an Editorial Workflows Blueprint resource.
  * @beta This feature is subject to breaking changes.
  * @category Resource Types
- * @interface
  */
-export interface DefineWorkflowsOptions {
+export interface BlueprintWorkflowsOptions {
   /**
    * The Blueprint resource name.
    * @defaultValue `editorial-workflows-<deployment name>`

--- a/src/types/workflows.ts
+++ b/src/types/workflows.ts
@@ -1,20 +1,32 @@
 import type {BlueprintResource, BlueprintResourceLifecycle} from '../index.js'
 
 /**
- * Resource types that can store Editorial Workflows data.
+ * Resource target types supported by Editorial Workflows.
  * @beta This feature is subject to breaking changes.
  * @category Resource Types
  */
 export const WORKFLOW_TARGET_TYPES = ['dataset', 'canvas', 'media-library', 'dashboard'] as const
 
 /**
- * A resource that can store Editorial Workflows data.
+ * A resource target type supported by Editorial Workflows.
+ * @beta This feature is subject to breaking changes.
+ * @category Resource Types
+ */
+export type BlueprintWorkflowTargetType = (typeof WORKFLOW_TARGET_TYPES)[number]
+
+/**
+ * A physical resource used by Editorial Workflows.
  * @beta This feature is subject to breaking changes.
  * @category Resource Types
  * @expand
  */
 export interface BlueprintWorkflowTarget {
-  type: (typeof WORKFLOW_TARGET_TYPES)[number]
+  /** The kind of resource. */
+  type: BlueprintWorkflowTargetType
+  /**
+   * The target-specific resource ID. Dataset IDs use `<projectId>.<dataset>`;
+   * other target types use their platform resource ID.
+   */
   id: string
 }
 
@@ -25,7 +37,9 @@ export interface BlueprintWorkflowTarget {
  * @expand
  */
 export interface BlueprintWorkflowResourceBinding {
+  /** The logical handle referenced by workflow definitions. */
   name: string
+  /** The physical resource bound to the handle. */
   resource: BlueprintWorkflowTarget
 }
 
@@ -36,6 +50,7 @@ export interface BlueprintWorkflowResourceBinding {
  * @expand
  */
 export interface BlueprintWorkflowDefinition {
+  /** The deployment-unique definition name. */
   name: string
 }
 
@@ -45,11 +60,17 @@ export interface BlueprintWorkflowDefinition {
  * @category Resource Types
  */
 export interface BlueprintWorkflowDeployment {
+  /** The deployment identity. */
   name: string
+  /** The persisted-data reader floor acknowledged by this deployment. */
   expectedMinReaderModel: number
+  /** The environment partition for workflow definitions and instances. */
   tag: string
+  /** The resource that stores engine-owned workflow data. */
   workflowResource: BlueprintWorkflowTarget
+  /** Logical resource handles available to the deployed definitions. */
   resourceAliases?: BlueprintWorkflowResourceBinding[]
+  /** The workflow definitions deployed together. */
   definitions: BlueprintWorkflowDefinition[]
 }
 

--- a/src/types/workflows.ts
+++ b/src/types/workflows.ts
@@ -23,7 +23,7 @@ export interface BlueprintWorkflowResourceBinding {
 }
 
 /**
- * The portion of an Editorial Workflows definition used by Blueprints validation.
+ * The required identifying portion of an Editorial Workflows definition.
  * @beta This feature is subject to breaking changes.
  * @category Resource Types
  * @expand
@@ -47,6 +47,15 @@ export interface BlueprintWorkflowDeployment {
 }
 
 /**
+ * The lifecycle policies supported by an Editorial Workflows Blueprint resource.
+ * @beta This feature is subject to breaking changes.
+ * @category Resource Types
+ */
+export interface BlueprintWorkflowsLifecycle extends BlueprintResourceLifecycle {
+  deletionPolicy?: 'retain' | 'protect'
+}
+
+/**
  * Options for an Editorial Workflows Blueprint resource.
  * @beta This feature is subject to breaking changes.
  * @category Resource Types
@@ -62,7 +71,7 @@ export interface DefineWorkflowsOptions {
    * The Blueprint lifecycle policy.
    * @defaultValue `{deletionPolicy: 'retain'}`
    */
-  lifecycle?: BlueprintResourceLifecycle
+  lifecycle?: BlueprintWorkflowsLifecycle
 }
 
 /**
@@ -71,7 +80,7 @@ export interface DefineWorkflowsOptions {
  * @category Resource Types
  */
 export interface BlueprintWorkflowsResource<Deployment extends BlueprintWorkflowDeployment = BlueprintWorkflowDeployment>
-  extends BlueprintResource {
+  extends BlueprintResource<BlueprintWorkflowsLifecycle> {
   type: 'sanity.workflow'
   deployment: Deployment
 }

--- a/src/validation/workflows.ts
+++ b/src/validation/workflows.ts
@@ -1,0 +1,193 @@
+import {type BlueprintError, validateResource} from '../index.js'
+
+const WORKFLOW_TARGET_TYPES = ['dataset', 'canvas', 'media-library', 'dashboard']
+
+/**
+ * Validates that the given resource is a valid Editorial Workflows resource.
+ * @param resource The Editorial Workflows resource
+ * @category Validation
+ * @returns A list of validation errors
+ */
+export function validateWorkflows(resource: unknown): BlueprintError[] {
+  if (!resource) return [{type: 'invalid_value', message: 'Editorial Workflows config must be provided'}]
+  if (typeof resource !== 'object') return [{type: 'invalid_type', message: 'Editorial Workflows config must be an object'}]
+
+  const errors = validateResource(resource)
+
+  if ('name' in resource && resource.name === '') {
+    errors.push({type: 'invalid_value', message: 'Editorial Workflows resource name must be a non-empty string'})
+  }
+
+  if (!('type' in resource)) {
+    errors.push({type: 'missing_parameter', message: 'Editorial Workflows type is required'})
+  } else if (resource.type !== 'sanity.workflow') {
+    errors.push({type: 'invalid_value', message: 'Editorial Workflows type must be `sanity.workflow`'})
+  }
+
+  if ('lifecycle' in resource && isRecord(resource.lifecycle)) {
+    const policy = valueAt(resource.lifecycle, 'deletionPolicy')
+    if (policy === 'allow' || policy === 'replace') {
+      errors.push({
+        type: 'invalid_value',
+        message: `Editorial Workflows deletion policy \`${policy}\` is not supported; definitions are retain-only through Blueprints`,
+      })
+    }
+  }
+
+  if (!('deployment' in resource)) {
+    errors.push({type: 'missing_parameter', message: 'Editorial Workflows deployment is required'})
+  } else {
+    errors.push(...validateWorkflowDeployment(resource.deployment))
+  }
+
+  return errors
+}
+
+function validateWorkflowDeployment(deployment: unknown): BlueprintError[] {
+  if (!isRecord(deployment)) return [{type: 'invalid_type', message: 'Editorial Workflows deployment must be an object'}]
+
+  const errors: BlueprintError[] = []
+  errors.push(...validateNonEmptyString(deployment, 'name', 'deployment name'))
+  errors.push(...validateNonEmptyString(deployment, 'tag', 'deployment tag'))
+
+  if (!('expectedMinReaderModel' in deployment)) {
+    errors.push({type: 'missing_parameter', message: 'Editorial Workflows expected minimum reader model is required'})
+  } else {
+    const expectedMinReaderModel = valueAt(deployment, 'expectedMinReaderModel')
+    if (!Number.isInteger(expectedMinReaderModel) || Number(expectedMinReaderModel) < 1) {
+      errors.push({type: 'invalid_value', message: 'Editorial Workflows expected minimum reader model must be a positive integer'})
+    }
+  }
+
+  if (!('workflowResource' in deployment)) {
+    errors.push({type: 'missing_parameter', message: 'Editorial Workflows target resource is required'})
+  } else {
+    errors.push(...validateWorkflowTarget(valueAt(deployment, 'workflowResource')))
+  }
+
+  const definitions = valueAt(deployment, 'definitions')
+  if (!('definitions' in deployment)) {
+    errors.push({type: 'missing_parameter', message: 'Editorial Workflows definitions array is required'})
+  } else if (!Array.isArray(definitions)) {
+    errors.push({type: 'invalid_type', message: 'Editorial Workflows definitions must be an array'})
+  } else if (definitions.length === 0) {
+    errors.push({type: 'invalid_value', message: 'Editorial Workflows deployment must contain at least one definition'})
+  } else {
+    errors.push(...validateDefinitions(definitions))
+  }
+
+  return errors
+}
+
+function validateNonEmptyString(value: Record<string, unknown>, key: string, label: string): BlueprintError[] {
+  if (!(key in value)) return [{type: 'missing_parameter', message: `Editorial Workflows ${label} is required`}]
+  if (typeof value[key] !== 'string') return [{type: 'invalid_type', message: `Editorial Workflows ${label} must be a string`}]
+  if (value[key] === '') return [{type: 'invalid_value', message: `Editorial Workflows ${label} must be a non-empty string`}]
+  return []
+}
+
+function validateWorkflowTarget(target: unknown): BlueprintError[] {
+  if (!isRecord(target)) return [{type: 'invalid_type', message: 'Editorial Workflows target resource must be an object'}]
+
+  const errors = validateNonEmptyString(target, 'id', 'target resource ID')
+  if (!('type' in target)) {
+    errors.push({type: 'missing_parameter', message: 'Editorial Workflows target resource type is required'})
+  } else {
+    const targetType = valueAt(target, 'type')
+    if (typeof targetType !== 'string' || !WORKFLOW_TARGET_TYPES.includes(targetType)) {
+      errors.push({
+        type: 'invalid_value',
+        message: `Editorial Workflows target resource type must be one of ${WORKFLOW_TARGET_TYPES.join(', ')}`,
+      })
+    }
+  }
+  return errors
+}
+
+function validateDefinitions(definitions: unknown[]): BlueprintError[] {
+  const errors = definitions.flatMap((definition) => {
+    if (!isRecord(definition)) return [{type: 'invalid_type', message: 'Editorial Workflows definition must be an object'}]
+    return validateNonEmptyString(definition, 'name', 'definition name')
+  })
+  const namedDefinitions = definitions.filter(isNamedDefinition)
+  const duplicate = firstDuplicateName(namedDefinitions)
+  if (duplicate !== undefined) {
+    errors.push({type: 'invalid_value', message: `Editorial Workflows definition name \`${duplicate}\` is duplicated`})
+  }
+  const cycle = firstCycleName(namedDefinitions)
+  if (cycle !== undefined) {
+    errors.push({type: 'invalid_value', message: `Editorial Workflows definitions contain a reference cycle involving \`${cycle}\``})
+  }
+  return errors
+}
+
+function firstDuplicateName(definitions: Array<Record<string, unknown> & {name: string}>): string | undefined {
+  const seen = new Set<string>()
+  for (const definition of definitions) {
+    if (seen.has(definition.name)) return definition.name
+    seen.add(definition.name)
+  }
+  return undefined
+}
+
+function firstCycleName(definitions: Array<Record<string, unknown> & {name: string}>): string | undefined {
+  const byName = new Map(definitions.map((definition) => [definition.name, definition]))
+  const visited = new Set<string>()
+  const visiting = new Set<string>()
+
+  function visit(name: string): string | undefined {
+    if (visited.has(name)) return undefined
+    if (visiting.has(name)) return name
+    const definition = byName.get(name)
+    if (definition === undefined) return undefined
+
+    visiting.add(name)
+    for (const reference of spawnReferenceNames(definition)) {
+      if (!byName.has(reference)) continue
+      const cycle = visit(reference)
+      if (cycle !== undefined) return cycle
+    }
+    visiting.delete(name)
+    visited.add(name)
+    return undefined
+  }
+
+  for (const name of byName.keys()) {
+    const cycle = visit(name)
+    if (cycle !== undefined) return cycle
+  }
+  return undefined
+}
+
+function spawnReferenceNames(definition: Record<string, unknown>): string[] {
+  return arrayAt(definition, 'stages')
+    .filter(isRecord)
+    .flatMap((stage) => arrayAt(stage, 'activities'))
+    .filter(isRecord)
+    .flatMap((activity) => arrayAt(activity, 'actions'))
+    .filter(isRecord)
+    .flatMap((action) => {
+      const spawn = valueAt(action, 'spawn')
+      if (!isRecord(spawn)) return []
+      const referencedDefinition = valueAt(spawn, 'definition')
+      if (!isRecord(referencedDefinition)) return []
+      const referencedName = valueAt(referencedDefinition, 'name')
+      return typeof referencedName === 'string' ? [referencedName] : []
+    })
+}
+
+function arrayAt(value: Record<string, unknown>, key: string): unknown[] {
+  return Array.isArray(value[key]) ? value[key] : []
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function valueAt(value: Record<string, unknown>, key: string): unknown {
+  return value[key]
+}
+
+function isNamedDefinition(value: unknown): value is Record<string, unknown> & {name: string} {
+  return isRecord(value) && typeof valueAt(value, 'name') === 'string'
+}

--- a/src/validation/workflows.ts
+++ b/src/validation/workflows.ts
@@ -18,9 +18,7 @@ export function validateWorkflows(resource: unknown): BlueprintError[] {
     errors.push({type: 'invalid_value', message: 'Editorial Workflows resource name must be a non-empty string'})
   }
 
-  if (!('type' in resource)) {
-    errors.push({type: 'missing_parameter', message: 'Editorial Workflows type is required'})
-  } else if (resource.type !== 'sanity.workflow') {
+  if ('type' in resource && resource.type !== 'sanity.workflow') {
     errors.push({type: 'invalid_value', message: 'Editorial Workflows type must be `sanity.workflow`'})
   }
 
@@ -29,7 +27,7 @@ export function validateWorkflows(resource: unknown): BlueprintError[] {
     if (policy === 'allow' || policy === 'replace') {
       errors.push({
         type: 'invalid_value',
-        message: `Editorial Workflows deletion policy \`${policy}\` is not supported; definitions are retain-only through Blueprints`,
+        message: `Editorial Workflows deletion policy \`${policy}\` is not supported; use \`retain\` (the default) or \`protect\``,
       })
     }
   }
@@ -65,6 +63,10 @@ function validateWorkflowDeployment(deployment: unknown): BlueprintError[] {
     errors.push(...validateWorkflowTarget(valueAt(deployment, 'workflowResource')))
   }
 
+  if ('resourceAliases' in deployment) {
+    errors.push(...validateResourceAliases(valueAt(deployment, 'resourceAliases')))
+  }
+
   const definitions = valueAt(deployment, 'definitions')
   if (!('definitions' in deployment)) {
     errors.push({type: 'missing_parameter', message: 'Editorial Workflows definitions array is required'})
@@ -76,6 +78,32 @@ function validateWorkflowDeployment(deployment: unknown): BlueprintError[] {
     errors.push(...validateDefinitions(definitions))
   }
 
+  return errors
+}
+
+function validateResourceAliases(resourceAliases: unknown): BlueprintError[] {
+  if (!Array.isArray(resourceAliases)) {
+    return [{type: 'invalid_type', message: 'Editorial Workflows resource aliases must be an array'}]
+  }
+
+  const errors = resourceAliases.flatMap((binding) => {
+    if (!isRecord(binding)) {
+      return [{type: 'invalid_type', message: 'Editorial Workflows resource alias must be an object'}]
+    }
+
+    const bindingErrors = validateNonEmptyString(binding, 'name', 'resource alias name')
+    if (!('resource' in binding)) {
+      bindingErrors.push({type: 'missing_parameter', message: 'Editorial Workflows resource alias target is required'})
+    } else {
+      bindingErrors.push(...validateWorkflowTarget(valueAt(binding, 'resource')))
+    }
+    return bindingErrors
+  })
+
+  const duplicate = firstDuplicateName(resourceAliases.filter(isNamedDefinition))
+  if (duplicate !== undefined) {
+    errors.push({type: 'invalid_value', message: `Editorial Workflows resource alias name \`${duplicate}\` is duplicated`})
+  }
   return errors
 }
 
@@ -121,7 +149,7 @@ function validateDefinitions(definitions: unknown[]): BlueprintError[] {
   return errors
 }
 
-function firstDuplicateName(definitions: Array<Record<string, unknown> & {name: string}>): string | undefined {
+function firstDuplicateName(definitions: Array<{name: string}>): string | undefined {
   const seen = new Set<string>()
   for (const definition of definitions) {
     if (seen.has(definition.name)) return definition.name
@@ -160,6 +188,8 @@ function firstCycleName(definitions: Array<Record<string, unknown> & {name: stri
 }
 
 function spawnReferenceNames(definition: Record<string, unknown>): string[] {
+  // Mirrors the workflow-engine authoring path without importing its large definition type.
+  // Unknown shapes intentionally contribute no references; tests pin this external-schema coupling.
   return arrayAt(definition, 'stages')
     .filter(isRecord)
     .flatMap((stage) => arrayAt(stage, 'activities'))

--- a/src/validation/workflows.ts
+++ b/src/validation/workflows.ts
@@ -22,6 +22,7 @@ export function validateWorkflows(resource: unknown): BlueprintError[] {
 
   if ('lifecycle' in resource && isRecord(resource.lifecycle)) {
     const policy = valueAt(resource.lifecycle, 'deletionPolicy')
+    // Base resource validation owns the complete policy allowlist; this narrows its accepted set for workflows.
     if (policy === 'allow' || policy === 'replace') {
       errors.push({
         type: 'invalid_value',
@@ -98,7 +99,7 @@ function validateResourceAliases(resourceAliases: unknown): BlueprintError[] {
     return bindingErrors
   })
 
-  const duplicate = firstDuplicateName(resourceAliases.filter(isNamedDefinition))
+  const duplicate = firstDuplicateName(resourceAliases.filter(hasStringName))
   if (duplicate !== undefined) {
     errors.push({type: 'invalid_value', message: `Editorial Workflows resource alias name \`${duplicate}\` is duplicated`})
   }
@@ -135,7 +136,7 @@ function validateDefinitions(definitions: unknown[]): BlueprintError[] {
     if (!isRecord(definition)) return [{type: 'invalid_type', message: 'Editorial Workflows definition must be an object'}]
     return validateNonEmptyString(definition, 'name', 'definition name')
   })
-  const namedDefinitions = definitions.filter(isNamedDefinition)
+  const namedDefinitions = definitions.filter(hasStringName)
   const duplicate = firstDuplicateName(namedDefinitions)
   if (duplicate !== undefined) {
     errors.push({type: 'invalid_value', message: `Editorial Workflows definition name \`${duplicate}\` is duplicated`})
@@ -217,6 +218,6 @@ function valueAt(value: Record<string, unknown>, key: string): unknown {
   return value[key]
 }
 
-function isNamedDefinition(value: unknown): value is Record<string, unknown> & {name: string} {
+function hasStringName(value: unknown): value is Record<string, unknown> & {name: string} {
   return isRecord(value) && typeof valueAt(value, 'name') === 'string'
 }

--- a/src/validation/workflows.ts
+++ b/src/validation/workflows.ts
@@ -1,6 +1,4 @@
-import {type BlueprintError, validateResource} from '../index.js'
-
-const WORKFLOW_TARGET_TYPES = ['dataset', 'canvas', 'media-library', 'dashboard']
+import {type BlueprintError, validateResource, WORKFLOW_TARGET_TYPES} from '../index.js'
 
 /**
  * Validates that the given resource is a valid Editorial Workflows resource.
@@ -122,7 +120,7 @@ function validateWorkflowTarget(target: unknown): BlueprintError[] {
     errors.push({type: 'missing_parameter', message: 'Editorial Workflows target resource type is required'})
   } else {
     const targetType = valueAt(target, 'type')
-    if (typeof targetType !== 'string' || !WORKFLOW_TARGET_TYPES.includes(targetType)) {
+    if (typeof targetType !== 'string' || !WORKFLOW_TARGET_TYPES.some((type) => type === targetType)) {
       errors.push({
         type: 'invalid_value',
         message: `Editorial Workflows target resource type must be one of ${WORKFLOW_TARGET_TYPES.join(', ')}`,
@@ -215,6 +213,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function valueAt(value: Record<string, unknown>, key: string): unknown {
+  // A variable key avoids Biome rewriting bracket access to dot access, which TypeScript rejects for index signatures.
   return value[key]
 }
 

--- a/src/validation/workflows.ts
+++ b/src/validation/workflows.ts
@@ -1,7 +1,11 @@
 import {type BlueprintError, validateResource, WORKFLOW_TARGET_TYPES} from '../index.js'
 
 /**
- * Validates that the given resource is a valid Editorial Workflows resource.
+ * Validates the Blueprint manifest envelope for an Editorial Workflows resource.
+ *
+ * This dependency-free validator checks resource metadata, deployment metadata, targets, aliases, and definition identities. It does not validate
+ * complete authored definitions. The registered resource provider must validate the external JSON boundary with the Editorial Workflows engine
+ * before provisioning it.
  * @param resource The Editorial Workflows resource
  * @category Validation
  * @returns A list of validation errors
@@ -27,6 +31,12 @@ export function validateWorkflows(resource: unknown): BlueprintError[] {
       errors.push({
         type: 'invalid_value',
         message: `Editorial Workflows deletion policy \`${policy}\` is not supported; use \`retain\` (the default) or \`protect\``,
+      })
+    }
+    if ('ownershipAction' in resource.lifecycle) {
+      errors.push({
+        type: 'invalid_value',
+        message: 'Editorial Workflows ownership actions are not supported until the resource provider defines stable ownership semantics',
       })
     }
   }
@@ -141,10 +151,6 @@ function validateDefinitions(definitions: unknown[]): BlueprintError[] {
   if (duplicate !== undefined) {
     errors.push({type: 'invalid_value', message: `Editorial Workflows definition name \`${duplicate}\` is duplicated`})
   }
-  const cycle = firstCycleName(namedDefinitions)
-  if (cycle !== undefined) {
-    errors.push({type: 'invalid_value', message: `Editorial Workflows definitions contain a reference cycle involving \`${cycle}\``})
-  }
   return errors
 }
 
@@ -155,58 +161,6 @@ function firstDuplicateName(definitions: Array<{name: string}>): string | undefi
     seen.add(definition.name)
   }
   return undefined
-}
-
-function firstCycleName(definitions: Array<Record<string, unknown> & {name: string}>): string | undefined {
-  const byName = new Map(definitions.map((definition) => [definition.name, definition]))
-  const visited = new Set<string>()
-  const visiting = new Set<string>()
-
-  function visit(name: string): string | undefined {
-    if (visited.has(name)) return undefined
-    if (visiting.has(name)) return name
-    const definition = byName.get(name)
-    if (definition === undefined) return undefined
-
-    visiting.add(name)
-    for (const reference of spawnReferenceNames(definition)) {
-      if (!byName.has(reference)) continue
-      const cycle = visit(reference)
-      if (cycle !== undefined) return cycle
-    }
-    visiting.delete(name)
-    visited.add(name)
-    return undefined
-  }
-
-  for (const name of byName.keys()) {
-    const cycle = visit(name)
-    if (cycle !== undefined) return cycle
-  }
-  return undefined
-}
-
-function spawnReferenceNames(definition: Record<string, unknown>): string[] {
-  // Mirrors the workflow-engine authoring path without importing its large definition type.
-  // Unknown shapes intentionally contribute no references; tests pin this external-schema coupling.
-  return arrayAt(definition, 'stages')
-    .filter(isRecord)
-    .flatMap((stage) => arrayAt(stage, 'activities'))
-    .filter(isRecord)
-    .flatMap((activity) => arrayAt(activity, 'actions'))
-    .filter(isRecord)
-    .flatMap((action) => {
-      const spawn = valueAt(action, 'spawn')
-      if (!isRecord(spawn)) return []
-      const referencedDefinition = valueAt(spawn, 'definition')
-      if (!isRecord(referencedDefinition)) return []
-      const referencedName = valueAt(referencedDefinition, 'name')
-      return typeof referencedName === 'string' ? [referencedName] : []
-    })
-}
-
-function arrayAt(value: Record<string, unknown>, key: string): unknown[] {
-  return Array.isArray(value[key]) ? value[key] : []
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/test/integration/imports.test.ts
+++ b/test/integration/imports.test.ts
@@ -13,6 +13,7 @@ import {
   defineRole,
   defineScheduledFunction,
   defineSyncTagInvalidateFunction,
+  defineWorkflows,
   validateBlueprint,
   validateCorsOrigin,
   validateDataset,
@@ -25,6 +26,7 @@ import {
   validateResource,
   validateRole,
   validateSyncTagInvalidateFunction,
+  validateWorkflows,
 } from '@sanity/blueprints'
 import {describe, expect, it} from 'vitest'
 
@@ -71,6 +73,10 @@ describe('package imports', () => {
 
   it('should import defineMediaLibraryAssetFunction', () => {
     expect(defineMediaLibraryAssetFunction).toBeInstanceOf(Function)
+  })
+
+  it('should import defineWorkflows', () => {
+    expect(defineWorkflows).toBeInstanceOf(Function)
   })
 
   it('should import defineProjectRole', () => {
@@ -123,6 +129,10 @@ describe('package imports', () => {
 
   it('should import validateMediaLibraryAssetFunction', () => {
     expect(validateMediaLibraryAssetFunction).toBeInstanceOf(Function)
+  })
+
+  it('should import validateWorkflows', () => {
+    expect(validateWorkflows).toBeInstanceOf(Function)
   })
 
   it('should import validateRole', () => {

--- a/test/integration/resources.typecheck.ts
+++ b/test/integration/resources.typecheck.ts
@@ -28,6 +28,7 @@ import {
   type BlueprintSyncTagInvalidateFunctionResource,
   type BlueprintSyncTagInvalidateFunctionResourceEvent,
   type BlueprintWorkflowDeployment,
+  type BlueprintWorkflowsOptions,
   type BlueprintWorkflowsResource,
   defineCorsOrigin,
   defineDataset,
@@ -144,7 +145,8 @@ const workflowDeployment: BlueprintWorkflowDeployment = {
   workflowResource: {type: 'dataset', id: 'projectId.dataset'},
   definitions: [{name: 'article-review'}],
 }
-const workflowsResource: BlueprintWorkflowsResource = defineWorkflows(workflowDeployment)
+const workflowsOptions: BlueprintWorkflowsOptions = {lifecycle: {deletionPolicy: 'protect'}}
+const workflowsResource: BlueprintWorkflowsResource = defineWorkflows(workflowDeployment, workflowsOptions)
 
 const queueFunction: BlueprintQueueFunctionResource = defineQueueFunction({
   name: 'stuff',

--- a/test/integration/resources.typecheck.ts
+++ b/test/integration/resources.typecheck.ts
@@ -30,6 +30,7 @@ import {
   type BlueprintWorkflowDeployment,
   type BlueprintWorkflowsOptions,
   type BlueprintWorkflowsResource,
+  type BlueprintWorkflowTargetType,
   defineCorsOrigin,
   defineDataset,
   defineDocumentFunction,
@@ -56,6 +57,7 @@ import {
   validateRole,
   validateScheduledFunction,
   validateSyncTagInvalidateFunction,
+  validateWorkflows,
   // type BlueprintsApiConfig,
   type WebhookTrigger,
 } from '@sanity/blueprints'
@@ -138,15 +140,17 @@ const syncTagInvalidateFunction: BlueprintSyncTagInvalidateFunctionResource = de
   event: fullyQualifiedSyncTagInvalidateFunctionResourceEvent,
 })
 
-const workflowDeployment: BlueprintWorkflowDeployment = {
-  name: 'production',
+const _workflowTargetType: BlueprintWorkflowTargetType = 'dataset'
+const workflowDeployment = {
+  name: 'production' as const,
   expectedMinReaderModel: 4,
   tag: 'production',
   workflowResource: {type: 'dataset', id: 'projectId.dataset'},
   definitions: [{name: 'article-review'}],
-}
+} satisfies BlueprintWorkflowDeployment
 const workflowsOptions: BlueprintWorkflowsOptions = {lifecycle: {deletionPolicy: 'protect'}}
-const workflowsResource: BlueprintWorkflowsResource = defineWorkflows(workflowDeployment, workflowsOptions)
+const workflowsResource: BlueprintWorkflowsResource<typeof workflowDeployment> = defineWorkflows(workflowDeployment, workflowsOptions)
+const _workflowDeploymentName: 'production' = workflowsResource.deployment.name
 
 const queueFunction: BlueprintQueueFunctionResource = defineQueueFunction({
   name: 'stuff',
@@ -266,5 +270,6 @@ validateResource(blueprintResource)
 validateRole(roleResource)
 validateScheduledFunction(scheduledFunctionResource)
 validateSyncTagInvalidateFunction(syncTagInvalidateFunction)
+validateWorkflows(workflowsResource)
 validateQueueFunction(queueFunction)
 validatePubSubFunction(pubSubFunction)

--- a/test/integration/resources.typecheck.ts
+++ b/test/integration/resources.typecheck.ts
@@ -141,16 +141,23 @@ const syncTagInvalidateFunction: BlueprintSyncTagInvalidateFunctionResource = de
 })
 
 const _workflowTargetType: BlueprintWorkflowTargetType = 'dataset'
+const articleReviewDefinition = {
+  name: 'article-review' as const,
+  title: 'Article review' as const,
+  initialStage: 'draft' as const,
+  stages: [{name: 'draft' as const}],
+}
 const workflowDeployment = {
   name: 'production' as const,
   expectedMinReaderModel: 4,
   tag: 'production',
   workflowResource: {type: 'dataset', id: 'projectId.dataset'},
-  definitions: [{name: 'article-review'}],
+  definitions: [articleReviewDefinition],
 } satisfies BlueprintWorkflowDeployment
 const workflowsOptions: BlueprintWorkflowsOptions = {lifecycle: {deletionPolicy: 'protect'}}
 const workflowsResource: BlueprintWorkflowsResource<typeof workflowDeployment> = defineWorkflows(workflowDeployment, workflowsOptions)
 const _workflowDeploymentName: 'production' = workflowsResource.deployment.name
+const _workflowDefinitionTitle: 'Article review' = workflowsResource.deployment.definitions[0].title
 
 const queueFunction: BlueprintQueueFunctionResource = defineQueueFunction({
   name: 'stuff',

--- a/test/integration/resources.typecheck.ts
+++ b/test/integration/resources.typecheck.ts
@@ -27,6 +27,8 @@ import {
   type BlueprintScheduledFunctionResourceEvent,
   type BlueprintSyncTagInvalidateFunctionResource,
   type BlueprintSyncTagInvalidateFunctionResourceEvent,
+  type BlueprintWorkflowDeployment,
+  type BlueprintWorkflowsResource,
   defineCorsOrigin,
   defineDataset,
   defineDocumentFunction,
@@ -38,6 +40,7 @@ import {
   defineRole,
   defineScheduledFunction,
   defineSyncTagInvalidateFunction,
+  defineWorkflows,
   type RolePermission,
   validateBlueprint,
   validateCorsOrigin,
@@ -133,6 +136,15 @@ const syncTagInvalidateFunction: BlueprintSyncTagInvalidateFunctionResource = de
   name: 'yoyoyo',
   event: fullyQualifiedSyncTagInvalidateFunctionResourceEvent,
 })
+
+const workflowDeployment: BlueprintWorkflowDeployment = {
+  name: 'production',
+  expectedMinReaderModel: 4,
+  tag: 'production',
+  workflowResource: {type: 'dataset', id: 'projectId.dataset'},
+  definitions: [{name: 'article-review'}],
+}
+const workflowsResource: BlueprintWorkflowsResource = defineWorkflows(workflowDeployment)
 
 const queueFunction: BlueprintQueueFunctionResource = defineQueueFunction({
   name: 'stuff',
@@ -230,6 +242,7 @@ const blueprint: Blueprint = {
     mediaLibraryAssetFunctionResource,
     projectRoleResource,
     blueprintResource,
+    workflowsResource,
   ],
   values: {
     key: 'value',

--- a/test/unit/definers/workflows.test.ts
+++ b/test/unit/definers/workflows.test.ts
@@ -46,7 +46,7 @@ describe('defineWorkflows', () => {
   })
 
   test.each(['allow', 'replace'] as const)('should reject the %s deletion policy', (deletionPolicy) => {
-    expect(() => workflows.defineWorkflows(deployment, {lifecycle: {deletionPolicy}})).toThrow(
+    expect(() => Reflect.apply(workflows.defineWorkflows, undefined, [deployment, {lifecycle: {deletionPolicy}}])).toThrow(
       `Editorial Workflows deletion policy \`${deletionPolicy}\` is not supported`,
     )
   })

--- a/test/unit/definers/workflows.test.ts
+++ b/test/unit/definers/workflows.test.ts
@@ -7,7 +7,7 @@ const deployment = {
   expectedMinReaderModel: 4,
   tag: 'production',
   workflowResource: {type: 'dataset' as const, id: 'projectId.dataset'},
-  definitions: [{name: 'article-review'}],
+  definitions: [{name: 'article-review', title: 'Article review', initialStage: 'draft', stages: [{name: 'draft'}]}],
 }
 
 describe('defineWorkflows', () => {
@@ -76,21 +76,14 @@ describe('defineWorkflows', () => {
     ).toThrow('Editorial Workflows definition name `article-review` is duplicated')
   })
 
-  test('should reject an in-set spawn reference cycle at define time', () => {
+  test('should reject ownership actions until the provider defines their semantics', () => {
     expect(() =>
-      workflows.defineWorkflows({
-        ...deployment,
-        definitions: [
-          {
-            name: 'article-review',
-            stages: [{activities: [{actions: [{spawn: {definition: {name: 'legal-review'}}}]}]}],
-          },
-          {
-            name: 'legal-review',
-            stages: [{activities: [{actions: [{spawn: {definition: {name: 'article-review'}}}]}]}],
-          },
-        ],
+      workflows.defineWorkflows(deployment, {
+        lifecycle: {
+          // @ts-expect-error Intentionally unsupported until the provider defines ownership semantics
+          ownershipAction: {type: 'detach'},
+        },
       }),
-    ).toThrow('Editorial Workflows definitions contain a reference cycle')
+    ).toThrow('Editorial Workflows ownership actions are not supported')
   })
 })

--- a/test/unit/definers/workflows.test.ts
+++ b/test/unit/definers/workflows.test.ts
@@ -46,12 +46,17 @@ describe('defineWorkflows', () => {
   })
 
   test.each(['allow', 'replace'] as const)('should reject the %s deletion policy', (deletionPolicy) => {
-    expect(() => Reflect.apply(workflows.defineWorkflows, undefined, [deployment, {lifecycle: {deletionPolicy}}])).toThrow(
-      `Editorial Workflows deletion policy \`${deletionPolicy}\` is not supported`,
-    )
+    expect(() =>
+      workflows.defineWorkflows(deployment, {
+        lifecycle: {
+          // @ts-expect-error Intentionally wrong type
+          deletionPolicy,
+        },
+      }),
+    ).toThrow(`Editorial Workflows deletion policy \`${deletionPolicy}\` is not supported`)
   })
 
-  test('should reject duplicate definition names at manifest evaluation', () => {
+  test('should reject duplicate definition names at define time', () => {
     expect(() =>
       workflows.defineWorkflows({
         ...deployment,
@@ -60,7 +65,7 @@ describe('defineWorkflows', () => {
     ).toThrow('Editorial Workflows definition name `article-review` is duplicated')
   })
 
-  test('should reject an in-set spawn reference cycle at manifest evaluation', () => {
+  test('should reject an in-set spawn reference cycle at define time', () => {
     expect(() =>
       workflows.defineWorkflows({
         ...deployment,

--- a/test/unit/definers/workflows.test.ts
+++ b/test/unit/definers/workflows.test.ts
@@ -45,6 +45,17 @@ describe('defineWorkflows', () => {
     })
   })
 
+  test('should retain the deletion policy when other lifecycle fields are provided', () => {
+    expect(
+      workflows.defineWorkflows(deployment, {
+        lifecycle: {dependsOn: '$.resources.content'},
+      }).lifecycle,
+    ).toStrictEqual({
+      deletionPolicy: 'retain',
+      dependsOn: '$.resources.content',
+    })
+  })
+
   test.each(['allow', 'replace'] as const)('should reject the %s deletion policy', (deletionPolicy) => {
     expect(() =>
       workflows.defineWorkflows(deployment, {

--- a/test/unit/definers/workflows.test.ts
+++ b/test/unit/definers/workflows.test.ts
@@ -1,0 +1,80 @@
+import {afterEach, describe, expect, test, vi} from 'vitest'
+import * as workflows from '../../../src/definers/workflows.js'
+import * as index from '../../../src/index.js'
+
+const deployment = {
+  name: 'production',
+  expectedMinReaderModel: 4,
+  tag: 'production',
+  workflowResource: {type: 'dataset' as const, id: 'projectId.dataset'},
+  definitions: [{name: 'article-review'}],
+}
+
+describe('defineWorkflows', () => {
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  test('should throw an error if validateWorkflows returns an error', () => {
+    const spy = vi.spyOn(index, 'validateWorkflows').mockImplementation(() => [{type: 'test', message: 'this is a test'}])
+
+    expect(() => workflows.defineWorkflows(deployment)).toThrow('this is a test')
+    expect(spy).toHaveBeenCalledOnce()
+  })
+
+  test('should set the resource type, retain lifecycle, and deployment-derived name', () => {
+    expect(workflows.defineWorkflows(deployment)).toStrictEqual({
+      name: 'editorial-workflows-production',
+      type: 'sanity.workflow',
+      lifecycle: {deletionPolicy: 'retain'},
+      deployment,
+    })
+  })
+
+  test('should accept an explicit resource name and protected lifecycle', () => {
+    expect(
+      workflows.defineWorkflows(deployment, {
+        name: 'editorial-workflows',
+        lifecycle: {deletionPolicy: 'protect'},
+      }),
+    ).toStrictEqual({
+      name: 'editorial-workflows',
+      type: 'sanity.workflow',
+      lifecycle: {deletionPolicy: 'protect'},
+      deployment,
+    })
+  })
+
+  test.each(['allow', 'replace'] as const)('should reject the %s deletion policy', (deletionPolicy) => {
+    expect(() => workflows.defineWorkflows(deployment, {lifecycle: {deletionPolicy}})).toThrow(
+      `Editorial Workflows deletion policy \`${deletionPolicy}\` is not supported`,
+    )
+  })
+
+  test('should reject duplicate definition names at manifest evaluation', () => {
+    expect(() =>
+      workflows.defineWorkflows({
+        ...deployment,
+        definitions: [{name: 'article-review'}, {name: 'article-review'}],
+      }),
+    ).toThrow('Editorial Workflows definition name `article-review` is duplicated')
+  })
+
+  test('should reject an in-set spawn reference cycle at manifest evaluation', () => {
+    expect(() =>
+      workflows.defineWorkflows({
+        ...deployment,
+        definitions: [
+          {
+            name: 'article-review',
+            stages: [{activities: [{actions: [{spawn: {definition: {name: 'legal-review'}}}]}]}],
+          },
+          {
+            name: 'legal-review',
+            stages: [{activities: [{actions: [{spawn: {definition: {name: 'article-review'}}}]}]}],
+          },
+        ],
+      }),
+    ).toThrow('Editorial Workflows definitions contain a reference cycle')
+  })
+})

--- a/test/unit/validation/workflows.test.ts
+++ b/test/unit/validation/workflows.test.ts
@@ -336,6 +336,30 @@ describe('validateWorkflows', () => {
     ).toStrictEqual([])
   })
 
+  test('should ignore malformed spawn-reference internals', () => {
+    expect(
+      validateWorkflows(
+        resourceWithDefinitions([
+          {name: 'invalid-stages', stages: 'invalid'},
+          {name: 'invalid-activities', stages: [{activities: 1}]},
+          {name: 'invalid-actions', stages: [{activities: [{actions: 1}]}]},
+          {
+            name: 'invalid-spawn',
+            stages: [{activities: [{actions: [{spawn: 'invalid'}]}]}],
+          },
+          {
+            name: 'invalid-spawn-definition',
+            stages: [{activities: [{actions: [{spawn: {definition: 'invalid'}}]}]}],
+          },
+          {
+            name: 'invalid-spawn-definition-name',
+            stages: [{activities: [{actions: [{spawn: {definition: {name: 1}}}]}]}],
+          },
+        ]),
+      ),
+    ).toStrictEqual([])
+  })
+
   test('should accept a valid resource', () => {
     expect(validateWorkflows(validResource)).toStrictEqual([])
   })

--- a/test/unit/validation/workflows.test.ts
+++ b/test/unit/validation/workflows.test.ts
@@ -1,6 +1,13 @@
 import {describe, expect, test} from 'vitest'
 import {type BlueprintError, type BlueprintWorkflowsResource, validateWorkflows} from '../../../src/index.js'
 
+const articleReviewDefinition = {
+  name: 'article-review',
+  title: 'Article review',
+  initialStage: 'draft',
+  stages: [{name: 'draft'}],
+}
+
 const validResource: BlueprintWorkflowsResource = {
   name: 'editorial-workflows-production',
   type: 'sanity.workflow',
@@ -10,7 +17,7 @@ const validResource: BlueprintWorkflowsResource = {
     expectedMinReaderModel: 4,
     tag: 'production',
     workflowResource: {type: 'dataset', id: 'projectId.dataset'},
-    definitions: [{name: 'article-review'}],
+    definitions: [articleReviewDefinition],
   },
 }
 
@@ -60,6 +67,13 @@ describe('validateWorkflows', () => {
     expect(validateWorkflows({...validResource, lifecycle: {deletionPolicy}})).toContainEqual({
       type: 'invalid_value',
       message: `Editorial Workflows deletion policy \`${deletionPolicy}\` is not supported; use \`retain\` (the default) or \`protect\``,
+    })
+  })
+
+  test('should reject ownership actions until the provider defines their semantics', () => {
+    expect(validateWorkflows({...validResource, lifecycle: {ownershipAction: {type: 'detach'}}})).toContainEqual({
+      type: 'invalid_value',
+      message: 'Editorial Workflows ownership actions are not supported until the resource provider defines stable ownership semantics',
     })
   })
 
@@ -269,95 +283,32 @@ describe('validateWorkflows', () => {
     })
   })
 
-  test('should reject a self-referencing definition', () => {
+  test('should collect all independent deployment errors in order', () => {
     expect(
-      validateWorkflows(
-        resourceWithDefinitions([
-          {
-            name: 'article-review',
-            stages: [{activities: [{actions: [{spawn: {definition: {name: 'article-review'}}}]}]}],
-          },
-        ]),
-      ),
-    ).toContainEqual({
-      type: 'invalid_value',
-      message: 'Editorial Workflows definitions contain a reference cycle involving `article-review`',
-    })
-  })
-
-  test('should reject a two-definition reference cycle', () => {
-    expect(
-      validateWorkflows(
-        resourceWithDefinitions([
-          {
-            name: 'article-review',
-            stages: [{activities: [{actions: [{spawn: {definition: {name: 'legal-review'}}}]}]}],
-          },
-          {
-            name: 'legal-review',
-            stages: [{activities: [{actions: [{spawn: {definition: {name: 'article-review'}}}]}]}],
-          },
-        ]),
-      ),
-    ).toContainEqual({
-      type: 'invalid_value',
-      message: 'Editorial Workflows definitions contain a reference cycle involving `article-review`',
-    })
-  })
-
-  test('should allow a shared-reference DAG', () => {
-    expect(
-      validateWorkflows(
-        resourceWithDefinitions([
-          {
-            name: 'article-review',
-            stages: [{activities: [{actions: [{spawn: {definition: {name: 'publish'}}}]}]}],
-          },
-          {
-            name: 'legal-review',
-            stages: [{activities: [{actions: [{spawn: {definition: {name: 'publish'}}}]}]}],
-          },
-          {name: 'publish'},
-        ]),
-      ),
-    ).toStrictEqual([])
-  })
-
-  test('should allow references to definitions outside the deployment', () => {
-    expect(
-      validateWorkflows(
-        resourceWithDefinitions([
-          {
-            name: 'article-review',
-            stages: [{activities: [{actions: [{spawn: {definition: {name: 'external-review'}}}]}]}],
-          },
-        ]),
-      ),
-    ).toStrictEqual([])
-  })
-
-  test('should ignore malformed spawn-reference internals', () => {
-    expect(
-      validateWorkflows(
-        resourceWithDefinitions([
-          {name: 'invalid-stages', stages: 'invalid'},
-          {name: 'invalid-activities', stages: [{activities: 1}]},
-          {name: 'invalid-actions', stages: [{activities: [{actions: 1}]}]},
-          {
-            name: 'invalid-spawn',
-            stages: [{activities: [{actions: [{spawn: 'invalid'}]}]}],
-          },
-          {
-            name: 'invalid-spawn-definition',
-            stages: [{activities: [{actions: [{spawn: {definition: 'invalid'}}]}]}],
-          },
-          {
-            name: 'invalid-spawn-definition-name',
-            stages: [{activities: [{actions: [{spawn: {definition: {name: 1}}}]}]}],
-          },
-        ]),
-      ),
-    ).toStrictEqual([])
+      validateWorkflows({
+        ...validResource,
+        deployment: {
+          name: '',
+          tag: 1,
+          expectedMinReaderModel: 0,
+          workflowResource: {type: 'invalid', id: ''},
+          resourceAliases: 'content',
+          definitions: [{}, {name: ''}],
+        },
+      }),
+    ).toStrictEqual([
+      {type: 'invalid_value', message: 'Editorial Workflows deployment name must be a non-empty string'},
+      {type: 'invalid_type', message: 'Editorial Workflows deployment tag must be a string'},
+      {type: 'invalid_value', message: 'Editorial Workflows expected minimum reader model must be a positive integer'},
+      {type: 'invalid_value', message: 'Editorial Workflows target resource ID must be a non-empty string'},
+      {
+        type: 'invalid_value',
+        message: 'Editorial Workflows target resource type must be one of dataset, canvas, media-library, dashboard',
+      },
+      {type: 'invalid_type', message: 'Editorial Workflows resource aliases must be an array'},
+      {type: 'missing_parameter', message: 'Editorial Workflows definition name is required'},
+      {type: 'invalid_value', message: 'Editorial Workflows definition name must be a non-empty string'},
+    ])
   })
 
   test('should accept a valid resource', () => {

--- a/test/unit/validation/workflows.test.ts
+++ b/test/unit/validation/workflows.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, test} from 'vitest'
-import {validateWorkflows} from '../../../src/index.js'
+import {type BlueprintError, type BlueprintWorkflowsResource, validateWorkflows} from '../../../src/index.js'
 
-const validResource = {
+const validResource: BlueprintWorkflowsResource = {
   name: 'editorial-workflows-production',
   type: 'sanity.workflow',
   lifecycle: {deletionPolicy: 'retain'},
@@ -12,6 +12,14 @@ const validResource = {
     workflowResource: {type: 'dataset', id: 'projectId.dataset'},
     definitions: [{name: 'article-review'}],
   },
+}
+
+function expectDeploymentError(deployment: unknown, error: BlueprintError): void {
+  expect(validateWorkflows({...validResource, deployment})).toContainEqual(error)
+}
+
+function resourceWithDefinitions(definitions: unknown[]): unknown {
+  return {...validResource, deployment: {...validResource.deployment, definitions}}
 }
 
 describe('validateWorkflows', () => {
@@ -29,6 +37,11 @@ describe('validateWorkflows', () => {
     })
   })
 
+  test('should report the base resource error once if type is missing', () => {
+    const {type: _type, ...resource} = validResource
+    expect(validateWorkflows(resource)).toStrictEqual([{type: 'missing_parameter', message: '`type` is required'}])
+  })
+
   test('should require the sanity.workflow resource type', () => {
     expect(validateWorkflows({...validResource, type: 'invalid'})).toContainEqual({
       type: 'invalid_value',
@@ -43,6 +56,13 @@ describe('validateWorkflows', () => {
     })
   })
 
+  test.each(['allow', 'replace'] as const)('should reject the %s deletion policy', (deletionPolicy) => {
+    expect(validateWorkflows({...validResource, lifecycle: {deletionPolicy}})).toContainEqual({
+      type: 'invalid_value',
+      message: `Editorial Workflows deletion policy \`${deletionPolicy}\` is not supported; use \`retain\` (the default) or \`protect\``,
+    })
+  })
+
   test('should require a deployment', () => {
     const {deployment: _deployment, ...resource} = validResource
     expect(validateWorkflows(resource)).toContainEqual({
@@ -51,57 +71,269 @@ describe('validateWorkflows', () => {
     })
   })
 
-  test('should require a positive expected minimum reader model', () => {
-    expect(
-      validateWorkflows({
-        ...validResource,
-        deployment: {...validResource.deployment, expectedMinReaderModel: 0},
-      }),
-    ).toContainEqual({
-      type: 'invalid_value',
-      message: 'Editorial Workflows expected minimum reader model must be a positive integer',
+  test('should require the deployment to be an object', () => {
+    expectDeploymentError('production', {
+      type: 'invalid_type',
+      message: 'Editorial Workflows deployment must be an object',
     })
   })
 
-  test('should require a supported target resource type', () => {
+  test.each([
+    ['name', 1, 'invalid_type', 'Editorial Workflows deployment name must be a string'],
+    ['name', '', 'invalid_value', 'Editorial Workflows deployment name must be a non-empty string'],
+    ['tag', 1, 'invalid_type', 'Editorial Workflows deployment tag must be a string'],
+    ['tag', '', 'invalid_value', 'Editorial Workflows deployment tag must be a non-empty string'],
+  ] as const)('should reject invalid deployment %s values', (field, value, type, message) => {
+    expectDeploymentError({...validResource.deployment, [field]: value}, {type, message})
+  })
+
+  test.each([
+    ['name', 'Editorial Workflows deployment name is required'],
+    ['tag', 'Editorial Workflows deployment tag is required'],
+  ] as const)('should require the deployment %s', (field, message) => {
+    const deployment = {...validResource.deployment} as Record<string, unknown>
+    delete deployment[field]
+    expectDeploymentError(deployment, {type: 'missing_parameter', message})
+  })
+
+  test('should require an expected minimum reader model', () => {
+    const {expectedMinReaderModel: _expectedMinReaderModel, ...deployment} = validResource.deployment
+    expectDeploymentError(deployment, {
+      type: 'missing_parameter',
+      message: 'Editorial Workflows expected minimum reader model is required',
+    })
+  })
+
+  test.each([0, 1.5, '4'])('should reject invalid expected minimum reader model %s', (expectedMinReaderModel) => {
+    expectDeploymentError(
+      {...validResource.deployment, expectedMinReaderModel},
+      {
+        type: 'invalid_value',
+        message: 'Editorial Workflows expected minimum reader model must be a positive integer',
+      },
+    )
+  })
+
+  test('should require a target resource', () => {
+    const {workflowResource: _workflowResource, ...deployment} = validResource.deployment
+    expectDeploymentError(deployment, {
+      type: 'missing_parameter',
+      message: 'Editorial Workflows target resource is required',
+    })
+  })
+
+  test('should require the target resource to be an object', () => {
+    expectDeploymentError(
+      {...validResource.deployment, workflowResource: 'dataset'},
+      {
+        type: 'invalid_type',
+        message: 'Editorial Workflows target resource must be an object',
+      },
+    )
+  })
+
+  test.each([
+    [{type: 'dataset'}, 'missing_parameter', 'Editorial Workflows target resource ID is required'],
+    [{type: 'dataset', id: 1}, 'invalid_type', 'Editorial Workflows target resource ID must be a string'],
+    [{type: 'dataset', id: ''}, 'invalid_value', 'Editorial Workflows target resource ID must be a non-empty string'],
+    [{id: 'resource'}, 'missing_parameter', 'Editorial Workflows target resource type is required'],
+    [
+      {type: 'invalid', id: 'resource'},
+      'invalid_value',
+      'Editorial Workflows target resource type must be one of dataset, canvas, media-library, dashboard',
+    ],
+  ] as const)('should reject an invalid target resource %#', (workflowResource, type, message) => {
+    expectDeploymentError({...validResource.deployment, workflowResource}, {type, message})
+  })
+
+  test('should require resource aliases to be an array', () => {
+    expectDeploymentError(
+      {...validResource.deployment, resourceAliases: 'content'},
+      {
+        type: 'invalid_type',
+        message: 'Editorial Workflows resource aliases must be an array',
+      },
+    )
+  })
+
+  test('should require each resource alias to be an object', () => {
+    expectDeploymentError(
+      {...validResource.deployment, resourceAliases: ['content']},
+      {
+        type: 'invalid_type',
+        message: 'Editorial Workflows resource alias must be an object',
+      },
+    )
+  })
+
+  test.each([
+    [{resource: {type: 'dataset', id: 'projectId.content'}}, 'missing_parameter', 'Editorial Workflows resource alias name is required'],
+    [
+      {name: 1, resource: {type: 'dataset', id: 'projectId.content'}},
+      'invalid_type',
+      'Editorial Workflows resource alias name must be a string',
+    ],
+    [
+      {name: '', resource: {type: 'dataset', id: 'projectId.content'}},
+      'invalid_value',
+      'Editorial Workflows resource alias name must be a non-empty string',
+    ],
+    [{name: 'content'}, 'missing_parameter', 'Editorial Workflows resource alias target is required'],
+  ] as const)('should reject an invalid resource alias %#', (binding, type, message) => {
+    expectDeploymentError({...validResource.deployment, resourceAliases: [binding]}, {type, message})
+  })
+
+  test('should validate a resource alias target', () => {
+    expectDeploymentError(
+      {
+        ...validResource.deployment,
+        resourceAliases: [{name: 'content', resource: {type: 'invalid', id: 'resource'}}],
+      },
+      {
+        type: 'invalid_value',
+        message: 'Editorial Workflows target resource type must be one of dataset, canvas, media-library, dashboard',
+      },
+    )
+  })
+
+  test('should reject duplicate resource alias names', () => {
+    const binding = {name: 'content', resource: {type: 'dataset', id: 'projectId.content'}}
+    expectDeploymentError(
+      {...validResource.deployment, resourceAliases: [binding, binding]},
+      {
+        type: 'invalid_value',
+        message: 'Editorial Workflows resource alias name `content` is duplicated',
+      },
+    )
+  })
+
+  test('should accept valid resource aliases', () => {
     expect(
       validateWorkflows({
         ...validResource,
-        deployment: {...validResource.deployment, workflowResource: {type: 'invalid', id: 'resource'}},
+        deployment: {
+          ...validResource.deployment,
+          resourceAliases: [{name: 'content', resource: {type: 'dataset', id: 'projectId.content'}}],
+        },
       }),
-    ).toContainEqual({
-      type: 'invalid_value',
-      message: 'Editorial Workflows target resource type must be one of dataset, canvas, media-library, dashboard',
+    ).toStrictEqual([])
+  })
+
+  test('should require a definitions array', () => {
+    const {definitions: _definitions, ...deployment} = validResource.deployment
+    expectDeploymentError(deployment, {
+      type: 'missing_parameter',
+      message: 'Editorial Workflows definitions array is required',
     })
+  })
+
+  test('should require definitions to be an array', () => {
+    expectDeploymentError(
+      {...validResource.deployment, definitions: 'article-review'},
+      {
+        type: 'invalid_type',
+        message: 'Editorial Workflows definitions must be an array',
+      },
+    )
   })
 
   test('should require at least one definition', () => {
-    expect(
-      validateWorkflows({
-        ...validResource,
-        deployment: {...validResource.deployment, definitions: []},
-      }),
-    ).toContainEqual({
-      type: 'invalid_value',
-      message: 'Editorial Workflows deployment must contain at least one definition',
+    expectDeploymentError(
+      {...validResource.deployment, definitions: []},
+      {
+        type: 'invalid_value',
+        message: 'Editorial Workflows deployment must contain at least one definition',
+      },
+    )
+  })
+
+  test('should require each definition to be an object', () => {
+    expect(validateWorkflows(resourceWithDefinitions(['article-review']))).toContainEqual({
+      type: 'invalid_type',
+      message: 'Editorial Workflows definition must be an object',
     })
   })
 
+  test.each([
+    [{}, 'missing_parameter', 'Editorial Workflows definition name is required'],
+    [{name: 1}, 'invalid_type', 'Editorial Workflows definition name must be a string'],
+    [{name: ''}, 'invalid_value', 'Editorial Workflows definition name must be a non-empty string'],
+  ] as const)('should reject an invalid definition %#', (definition, type, message) => {
+    expect(validateWorkflows(resourceWithDefinitions([definition]))).toContainEqual({type, message})
+  })
+
+  test('should reject duplicate definition names', () => {
+    expect(validateWorkflows(resourceWithDefinitions([{name: 'article-review'}, {name: 'article-review'}]))).toContainEqual({
+      type: 'invalid_value',
+      message: 'Editorial Workflows definition name `article-review` is duplicated',
+    })
+  })
+
+  test('should reject a self-referencing definition', () => {
+    expect(
+      validateWorkflows(
+        resourceWithDefinitions([
+          {
+            name: 'article-review',
+            stages: [{activities: [{actions: [{spawn: {definition: {name: 'article-review'}}}]}]}],
+          },
+        ]),
+      ),
+    ).toContainEqual({
+      type: 'invalid_value',
+      message: 'Editorial Workflows definitions contain a reference cycle involving `article-review`',
+    })
+  })
+
+  test('should reject a two-definition reference cycle', () => {
+    expect(
+      validateWorkflows(
+        resourceWithDefinitions([
+          {
+            name: 'article-review',
+            stages: [{activities: [{actions: [{spawn: {definition: {name: 'legal-review'}}}]}]}],
+          },
+          {
+            name: 'legal-review',
+            stages: [{activities: [{actions: [{spawn: {definition: {name: 'article-review'}}}]}]}],
+          },
+        ]),
+      ),
+    ).toContainEqual({
+      type: 'invalid_value',
+      message: 'Editorial Workflows definitions contain a reference cycle involving `article-review`',
+    })
+  })
+
+  test('should allow a shared-reference DAG', () => {
+    expect(
+      validateWorkflows(
+        resourceWithDefinitions([
+          {
+            name: 'article-review',
+            stages: [{activities: [{actions: [{spawn: {definition: {name: 'publish'}}}]}]}],
+          },
+          {
+            name: 'legal-review',
+            stages: [{activities: [{actions: [{spawn: {definition: {name: 'publish'}}}]}]}],
+          },
+          {name: 'publish'},
+        ]),
+      ),
+    ).toStrictEqual([])
+  })
+
   test('should allow references to definitions outside the deployment', () => {
-    const errors = validateWorkflows({
-      ...validResource,
-      deployment: {
-        ...validResource.deployment,
-        definitions: [
+    expect(
+      validateWorkflows(
+        resourceWithDefinitions([
           {
             name: 'article-review',
             stages: [{activities: [{actions: [{spawn: {definition: {name: 'external-review'}}}]}]}],
           },
-        ],
-      },
-    })
-
-    expect(errors).toStrictEqual([])
+        ]),
+      ),
+    ).toStrictEqual([])
   })
 
   test('should accept a valid resource', () => {

--- a/test/unit/validation/workflows.test.ts
+++ b/test/unit/validation/workflows.test.ts
@@ -1,0 +1,110 @@
+import {describe, expect, test} from 'vitest'
+import {validateWorkflows} from '../../../src/index.js'
+
+const validResource = {
+  name: 'editorial-workflows-production',
+  type: 'sanity.workflow',
+  lifecycle: {deletionPolicy: 'retain'},
+  deployment: {
+    name: 'production',
+    expectedMinReaderModel: 4,
+    tag: 'production',
+    workflowResource: {type: 'dataset', id: 'projectId.dataset'},
+    definitions: [{name: 'article-review'}],
+  },
+}
+
+describe('validateWorkflows', () => {
+  test('should return an error if config is falsey', () => {
+    expect(validateWorkflows(undefined)).toContainEqual({
+      type: 'invalid_value',
+      message: 'Editorial Workflows config must be provided',
+    })
+  })
+
+  test('should return an error if config is not an object', () => {
+    expect(validateWorkflows(1)).toContainEqual({
+      type: 'invalid_type',
+      message: 'Editorial Workflows config must be an object',
+    })
+  })
+
+  test('should require the sanity.workflow resource type', () => {
+    expect(validateWorkflows({...validResource, type: 'invalid'})).toContainEqual({
+      type: 'invalid_value',
+      message: 'Editorial Workflows type must be `sanity.workflow`',
+    })
+  })
+
+  test('should require a non-empty resource name', () => {
+    expect(validateWorkflows({...validResource, name: ''})).toContainEqual({
+      type: 'invalid_value',
+      message: 'Editorial Workflows resource name must be a non-empty string',
+    })
+  })
+
+  test('should require a deployment', () => {
+    const {deployment: _deployment, ...resource} = validResource
+    expect(validateWorkflows(resource)).toContainEqual({
+      type: 'missing_parameter',
+      message: 'Editorial Workflows deployment is required',
+    })
+  })
+
+  test('should require a positive expected minimum reader model', () => {
+    expect(
+      validateWorkflows({
+        ...validResource,
+        deployment: {...validResource.deployment, expectedMinReaderModel: 0},
+      }),
+    ).toContainEqual({
+      type: 'invalid_value',
+      message: 'Editorial Workflows expected minimum reader model must be a positive integer',
+    })
+  })
+
+  test('should require a supported target resource type', () => {
+    expect(
+      validateWorkflows({
+        ...validResource,
+        deployment: {...validResource.deployment, workflowResource: {type: 'invalid', id: 'resource'}},
+      }),
+    ).toContainEqual({
+      type: 'invalid_value',
+      message: 'Editorial Workflows target resource type must be one of dataset, canvas, media-library, dashboard',
+    })
+  })
+
+  test('should require at least one definition', () => {
+    expect(
+      validateWorkflows({
+        ...validResource,
+        deployment: {...validResource.deployment, definitions: []},
+      }),
+    ).toContainEqual({
+      type: 'invalid_value',
+      message: 'Editorial Workflows deployment must contain at least one definition',
+    })
+  })
+
+  test('should allow references to definitions outside the deployment', () => {
+    const errors = validateWorkflows({
+      ...validResource,
+      deployment: {
+        ...validResource.deployment,
+        definitions: [
+          {
+            name: 'article-review',
+            stages: [{activities: [{actions: [{spawn: {definition: {name: 'external-review'}}}]}]}],
+          },
+        ],
+      },
+    })
+
+    expect(errors).toStrictEqual([])
+  })
+
+  test('should accept a valid resource', () => {
+    expect(validateWorkflows(validResource)).toStrictEqual([])
+  })
+})


### PR DESCRIPTION
[EDEX-1732](https://linear.app/sanity/issue/EDEX-1732/deploy-editorial-workflows-end-to-end-through-sanity-blueprints)

### At a glance

- Adds beta, manifest-side `defineWorkflows` support to `@sanity/blueprints`.
- Follows the repository's resource cadence: public types, collect-all validation, a validating definer, root exports, unit coverage, and installed-package type/import coverage, without adding an engine dependency.
- Explicitly does not make Editorial Workflows deployable through Blueprints yet: the Blueprints API has no registered `sanity.workflow` provider.
- No upgrade action required; this is an additive beta API.

### Current rollout status: not deployable yet

This PR implements the public `@sanity/blueprints` helper before the required provider package and server registration have shipped. The current Blueprints API registry throws for unknown resource types and has no `sanity.workflow` entry, so `blueprints deploy` cannot execute this resource. Keep this PR draft and unreleased until the provider is registered and the staging matrix passes. Until then, users must deploy definitions with `sanity-workflows deploy`.

This is not an oclif plugin or a `runtime-cli` command change. The existing `blueprints deploy` command submits the manifest; a private Resource Provider SDK package uses the deployment caller's token with `@sanity/client` for Content Lake provisioning, and the Blueprints API supplies orchestration, state, rollback, retain/detach, and provider dispatch.

### PR composition

| Change | Files | Added | Removed |
| :-- | --: | --: | --: |
| Product code | 4 | +360 | -0 |
| Tests | 4 | +443 | -0 |
| Docs | 1 | +6 | -1 |
| **Total** | **9** | **+809** | **-1** |

**Packages:** `@sanity/blueprints`

### Description

`defineWorkflows` emits a `sanity.workflow` manifest resource, derives its default resource name from the deployment name, and applies `retain` as the deletion-policy default even when callers provide other lifecycle fields. The dependency-free validator checks the resource/deployment envelope, supported targets, aliases, definition identities, and duplicates while collecting all independent errors.

Complete Editorial Workflows definition validation deliberately remains in the engine-aware `@sanity/workflow-blueprint` wrapper and at the provider's external JSON boundary, where the engine owns the authoring schema and reference semantics. This package no longer copies the engine's spawn-reference traversal. The generic return type preserves richer authored definition shapes, and the installed-package typecheck proves that preservation with an engine-valid example.

Lifecycle types accept `retain`, `protect`, and `dependsOn`. They reject deletion-requesting policies and exclude ownership actions because the provider does not support attach, detach, or cross-stack reference. These client checks are manifest feedback only; the provider independently rejects unsupported lifecycle input at every mutating boundary because Blueprints service validation may be disabled.

### End-to-end work required before release

- [EDEX-2062](https://linear.app/sanity/issue/EDEX-2062) hardens the existing workflow package: raw lifecycle enforcement, retain-default merging, partition identity, actual-Lake read receipts, exact rollback primitives, and the cross-package constructor contract.
- [EDEX-2061](https://linear.app/sanity/issue/EDEX-2061) creates the private Resource Provider SDK package with `validate`, `create`, `read`, `list`, `update`, and defensive `destroy`, plus caller-token client construction and factory metadata.
- [EDEX-2063](https://linear.app/sanity/issue/EDEX-2063) installs that package in the Blueprints API, registers `sanity.workflow`, assigns the `WF` prefix, and adds coordinator coverage.
- [EDEX-2064](https://linear.app/sanity/issue/EDEX-2064) proves the staging matrix and then removes this PR's temporary unavailable warning.

The physical `externalId` is the collision-safe `(workflowResource, tag)` partition, matching the engine's no-shared-partition invariant and the Blueprints database's global `(type, externalId)` uniqueness. The Blueprint resource name and deployment name remain logical selectors; including either in physical identity would allow separate resources to compete over the same definition namespace.

Blueprints' existing lifecycle coordinator provides the desired retain behavior: removing the whole resource from a normal manifest update fails, while destroying the whole stack detaches the Blueprints record without invoking provider `destroy`. Removing one definition from the aggregate deployment is an update, so its immutable versions remain in the Lake. Rollback deletes only definition versions marked `created` by the failed deploy receipt, in reverse dependency order and by exact version; it never treats a committed manifest removal as deletion.

`@sanity/blueprints` owns canonical resource shape and construction. `@sanity/workflow-blueprint` remains the engine-aware wrapper: it validates through the engine and then delegates construction to this definer. It must not become a plain re-export because that would lose eager GROQ, alias, reader-floor, duplicate-name, and spawn-cycle validation. The cross-package contract suite belongs in the workflows repository, which can depend on both packages.

### What to review

- Whether the dependency-free public deployment envelope is the correct canonical manifest contract while the workflow wrapper/provider own complete engine validation.
- Whether the narrowed lifecycle surface accurately represents the verified provider behavior: retain/protect only, no ownership actions, whole-resource removal failure, and stack-destroy detach.
- Whether the public types preserve rich authored definitions without creating an engine dependency.
- Whether the installed-package coverage and documentation make the temporary rollout gate unmistakable.

### Review rounds (4)

- Round 1 — Claude Fable 5, full PR `f0cfaa19...1376c3f`: identified six implementation/documentation fix clusters and two architecture escalations; accepted fixes landed in `0c0f40d`.
- Round 2 — Claude Fable 5, full PR `f0cfaa19...0c0f40d`: identified six convention/test fix clusters and reconfirmed the two escalations; accepted fixes landed in `0686f8c`.
- Round 3 — Claude Fable 5, final full-PR closure `f0cfaa19...0686f8c`: all nine changed files were read in full by all seven lenses. Binding adjudication upheld 16 proposed dismissals and overturned one. Seven accepted fix clusters landed in `0686f8c..f8c76e9`.
- Round 4 — Codex GPT-5 family, seven fresh local lenses over the full PR at `f8c76e9` plus the complete Provider SDK guide, current SDK types, live Blueprints API registry, and existing Editorial Workflows provider core. The review found seven deduplicated must-fix clusters and four provider/rollout escalations; accepted fixes landed in `92ccbe1`. The fix delta passed the full repository suite, installed-package checks, build, lint, and TypeDoc generation; it has not received a fifth formal lens round.
